### PR TITLE
feat: enhance panel performance, UI and referenced + fixed concurrent request bug

### DIFF
--- a/docs/panel-roles.md
+++ b/docs/panel-roles.md
@@ -1,0 +1,121 @@
+# Panel Roles, Reference
+
+This is the canonical map of who's on the Deep Plan panel at each phase
+and what job each role is actually given, taken verbatim from the system
+prompts in [src/main/features/deepPlan/prompts.ts](../src/main/features/deepPlan/prompts.ts).
+
+The panel is deliberately **phase-specific**. Ideation panels open doors;
+planning panels structure the argument; reviewing panels stress-test it.
+Every role has a narrow lens, none of them try to "do everything".
+
+Each role's output each round is a small JSON object:
+
+```json
+{
+  "visionNotes": "≤ 2 sentences observation through this role's lens, or ''",
+  "needsResearch": [{"query": "...", "rationale": "..."}]
+}
+```
+
+The panel's job is to steer the vision + propose research when the wiki has coverage gaps.
+
+## Who fires when
+
+| Phase      | Roles                                                   |
+| ---------- | ------------------------------------------------------- |
+| ideation   | Explorer · Scoper · Stakes-Raiser                       |
+| planning   | Architect · Evidence Scout · Steelman · Skeptic         |
+| reviewing  | Adversary · Editor · Audience · Finaliser               |
+| done       | (no panel, drafter runs instead)                       |
+
+## Ideation panel, opening doors
+
+**Explorer**
+Expand the problem space. Look for adjacent angles, analogies, framings,
+or sub-topics the vision has not considered. When the thesis is vague,
+propose concrete directions it could take. Opens doors; does not close
+them.
+
+**Scoper**
+Push the vision toward concreteness. Flag anything vague, a fuzzy
+thesis, an unnamed audience, an abstract claim that needs a specific
+example, a scope too broad for the length. Each note names one specific
+abstraction and demands a specific answer.
+
+**Stakes-Raiser**
+Force "so what?" and "for whom?". If the stakes are unclear, the piece
+has no reason to exist. Every note names a stake that's missing or
+under-articulated.
+
+## Planning panel, structuring the argument
+
+**Argument Architect**
+Propose or stress-test the thesis chain, the sub-claims that must hold
+for the main claim to hold. Flag where the chain breaks, where a
+sub-claim is load-bearing but unsupported, where a better framing
+exists.
+
+**Evidence Scout**
+Identify claims the piece makes (or will make) that need external
+evidence. Notes and research requests point to gaps in the wiki.
+Prefers primary sources, papers, official docs, firsthand accounts.
+
+**Steelman**
+Construct the strongest opposing position to the emerging thesis. State
+it charitably and accurately. Then check whether the vision has a
+response, if not, that's high-severity: the piece will fall to this
+objection unless it's addressed.
+
+**Skeptic**
+Find claims that would collapse under pressure, unstated assumptions,
+weak evidence, logical gaps, overreach. Names a specific claim and the
+specific failure mode. Does not raise stylistic issues (that's the
+Editor's job).
+
+## Reviewing panel, stress-testing
+
+**Adversary**
+Read the piece as a hostile reviewer would. Where is the argument most
+vulnerable? What will a reader attack first? What question will stop
+them dead on first read? Framing: "a hostile reader will say: …".
+
+**Editor**
+Look for redundancy, broken through-lines, pacing problems, and
+coherence gaps in the section structure. Names specific sections or
+beats and why they don't carry their weight. Suggests cuts and
+reorderings.
+
+**Audience**
+Inhabit the stated reader. What will land? What will confuse? What do
+they already know (so don't belabour it)? What do they not know (so
+explain it)? Predicts the reader's reaction to specific passages.
+
+**Finaliser**
+Propose the concrete section-by-section beat sheet the drafter will
+use. Each beat is a short "BEAT: <title>, <intent>" line. 4–8 beats in
+reading order. The Chair folds these into the final vision.
+
+## What users see
+
+Each Chair summary carries its round's full panel output. The UI
+surfaces it under the Chair's reply as a collapsed **Panel discussion**
+accordion, click to expand and see each role's note + research
+requests. Silent roles (no notes this round) are still listed, greyed
+out, so you can tell they ran and had nothing to add vs. they didn't
+fire at all.
+
+## The Chair
+
+The Chair is separate, it runs AFTER the panel each round, reads every
+role's output, and emits:
+
+- a short conversational summary to the user
+- an optional vision.md rewrite (only when the round genuinely moves
+  the thesis)
+- 0–3 targeted questions when a judgment call needs the user
+- a `requirementsPatch` when the user's last answers touched a hard
+  requirement (word count, form, audience)
+
+The Chair does NOT touch the anchor log. The Chair does NOT curate
+panel findings. Its job is steering, synthesising, and keeping the
+conversation with the user going.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,6 +19,11 @@ files:
 asarUnpack: []
 
 mac:
+  # Space-free artifact name. productName has a space ("Open Myst") which
+  # GitHub's asset upload rewrites to a dot, breaking the updater's URL
+  # lookup (latest-mac.yml still advertises the hyphen form). Hard-coding
+  # the hyphen name avoids the mismatch.
+  artifactName: Open-Myst-${version}-${arch}-mac.${ext}
   category: public.app-category.productivity
   target:
     - target: dmg
@@ -53,14 +58,14 @@ mac:
           - openmyst
 
 dmg:
-  artifactName: ${productName}-${version}-${arch}.dmg
+  artifactName: Open-Myst-${version}-${arch}.${ext}
 
 win:
   target:
     - target: nsis
       arch:
         - x64
-  artifactName: ${productName}-${version}-setup.${ext}
+  artifactName: Open-Myst-${version}-setup.${ext}
 
 nsis:
   oneClick: false
@@ -81,7 +86,7 @@ linux:
       arch:
         - x64
   category: Office
-  artifactName: ${productName}-${version}-${arch}.${ext}
+  artifactName: Open-Myst-${version}-${arch}.${ext}
   # The `protocols:` block above also writes a MimeType=x-scheme-handler/openmyst
   # entry into the .desktop file for the Linux AppImage.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmyst",
   "productName": "Open Myst",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "An open-source desktop research companion. Write, comment, and let an LLM propose inline edits against your own knowledge wiki.",
   "author": "Open Myst",

--- a/src/main/features/chat/turn.ts
+++ b/src/main/features/chat/turn.ts
@@ -201,12 +201,14 @@ export async function runTurn(ctx: TurnContext): Promise<ChatMessage> {
 
   log('chat', 'turn.systemPrompt', { chars: systemContent.length });
 
-  let fullContent = await streamChat({
-    model,
-    messages,
-    logScope: 'chat',
-    onChunk: (chunk) => broadcast(IpcChannels.Chat.Chunk, chunk),
-  });
+  let fullContent = (
+    await streamChat({
+      model,
+      messages,
+      logScope: 'chat',
+      onChunk: (chunk) => broadcast(IpcChannels.Chat.Chunk, chunk),
+    })
+  ).content;
 
   // Deep reference: if the LLM emitted source_lookup or web_search blocks,
   // resolve them (disk for source_lookup, live search backend for
@@ -251,12 +253,14 @@ export async function runTurn(ctx: TurnContext): Promise<ChatMessage> {
       { role: 'assistant', content: fullContent },
       { role: 'user', content: followUp },
     ];
-    fullContent = await streamChat({
-      model,
-      messages: replayMessages,
-      logScope: 'chat',
-      onChunk: (chunk) => broadcast(IpcChannels.Chat.Chunk, chunk),
-    });
+    fullContent = (
+      await streamChat({
+        model,
+        messages: replayMessages,
+        logScope: 'chat',
+        onChunk: (chunk) => broadcast(IpcChannels.Chat.Chunk, chunk),
+      })
+    ).content;
   }
 
   // Strip any residual lookup/search fences before handing to edit parsing.
@@ -319,11 +323,13 @@ export async function runTurn(ctx: TurnContext): Promise<ChatMessage> {
           `Now emit the myst_edit block to fulfil the original request: "${userText.slice(0, 200)}"`,
       },
     ];
-    const retryContent = await streamChat({
-      model,
-      messages: retryMessages,
-      logScope: 'chat',
-    });
+    const retryContent = (
+      await streamChat({
+        model,
+        messages: retryMessages,
+        logScope: 'chat',
+      })
+    ).content;
     const retryResult = parseEditBlocks(retryContent);
     if (retryResult.edits.length > 0) {
       edits = retryResult.edits;
@@ -345,11 +351,13 @@ export async function runTurn(ctx: TurnContext): Promise<ChatMessage> {
             `Re-emit the failed myst_edit blocks. Keep old_string SHORT — one sentence ideally, never more than a few. Copy the exact snippet from the document character-for-character (quotes, dashes, whitespace). For ambiguous matches, add an "occurrence" field (1-indexed).`,
         },
       ];
-      const retryContent = await streamChat({
-        model,
-        messages: retryMessages,
-        logScope: 'chat',
-      });
+      const retryContent = (
+        await streamChat({
+          model,
+          messages: retryMessages,
+          logScope: 'chat',
+        })
+      ).content;
       const retryResult = parseEditBlocks(retryContent);
       let resolved = false;
       if (retryResult.edits.length > 0) {

--- a/src/main/features/deepPlan/index.ts
+++ b/src/main/features/deepPlan/index.ts
@@ -77,7 +77,7 @@ function appendMessage(
   role: DeepPlanMessage['role'],
   content: string,
   kind: DeepPlanMessage['kind'] = 'chat',
-  extra: Partial<Pick<DeepPlanMessage, 'chair' | 'answers'>> = {},
+  extra: Partial<Pick<DeepPlanMessage, 'chair' | 'answers' | 'panel'>> = {},
 ): DeepPlanSession {
   const msg: DeepPlanMessage = {
     id: randomUUID(),
@@ -369,6 +369,7 @@ async function runPanelAndChair(): Promise<void> {
     await updateSession((s) => {
       const next = appendMessage(s, 'assistant', chairOutput.summary, 'chair-turn', {
         chair: chairOutput,
+        panel: panelOutputs,
       });
       const patch = chairOutput.requirementsPatch;
       const mergedRequirements = patch

--- a/src/main/features/deepPlan/index.ts
+++ b/src/main/features/deepPlan/index.ts
@@ -72,6 +72,27 @@ function estimateTokensK(chars: number): number {
   return chars / 4000;
 }
 
+function countWords(text: string): number {
+  const match = text.trim().match(/\S+/g);
+  return match ? match.length : 0;
+}
+
+/**
+ * Prefix a partial draft with a visible cut-off banner. Fires when the
+ * drafter's stream ends without `[DONE]` — almost always a proxy timeout
+ * on the managed backend. Saving the partial (rather than throwing) means
+ * the user keeps every token that did stream through, and the banner makes
+ * it obvious the draft needs a re-run to finish.
+ */
+function prependCutOffBanner(partial: string): string {
+  const words = countWords(partial);
+  const banner =
+    `> ⚠️ **Draft was cut off mid-generation** — ${words} word${words === 1 ? '' : 's'} below. ` +
+    `The upstream stream timed out before the drafter could finish. ` +
+    `Re-run the one-shot to regenerate, or keep editing from here.\n\n---\n\n`;
+  return banner + partial;
+}
+
 function appendMessage(
   session: DeepPlanSession,
   role: DeepPlanMessage['role'],
@@ -414,8 +435,8 @@ async function runPanelAndChair(): Promise<void> {
 async function streamWithLookupResolution(args: {
   model: string;
   messages: LlmMessage[];
-}): Promise<string> {
-  let content = await streamChat({
+}): Promise<{ content: string; complete: boolean }> {
+  let result = await streamChat({
     model: args.model,
     messages: args.messages,
     logScope: 'deep-plan',
@@ -423,17 +444,20 @@ async function streamWithLookupResolution(args: {
   });
 
   for (let round = 0; round < MAX_LOOKUP_ROUNDS; round++) {
-    const { requests } = parseSourceLookups(content);
+    const { requests } = parseSourceLookups(result.content);
     if (requests.length === 0) break;
+    // If the current round was cut off, don't chase lookups — resolve with
+    // what we have so the caller can rescue the partial.
+    if (!result.complete) break;
     log('deep-plan', 'sourceLookup.round', { round, count: requests.length });
     const resolved = await resolveSourceLookups(requests);
     const followUp = formatLookupReply(resolved);
     const replayMessages: LlmMessage[] = [
       ...args.messages,
-      { role: 'assistant', content },
+      { role: 'assistant', content: result.content },
       { role: 'user', content: followUp },
     ];
-    content = await streamChat({
+    result = await streamChat({
       model: args.model,
       messages: replayMessages,
       logScope: 'deep-plan',
@@ -441,7 +465,8 @@ async function streamWithLookupResolution(args: {
     });
   }
 
-  return parseSourceLookups(content).stripped || content;
+  const stripped = parseSourceLookups(result.content).stripped || result.content;
+  return { content: stripped, complete: result.complete };
 }
 
 export async function runOneShot(): Promise<DeepPlanStatus> {
@@ -479,8 +504,11 @@ export async function runOneShot(): Promise<DeepPlanStatus> {
   });
 
   let fullContent = '';
+  let complete = false;
   try {
-    fullContent = await streamWithLookupResolution({ model, messages });
+    const result = await streamWithLookupResolution({ model, messages });
+    fullContent = result.content;
+    complete = result.complete;
   } catch (err) {
     logError('deep-plan', 'oneshot.failed', err);
     broadcast(IpcChannels.DeepPlan.ChunkDone);
@@ -494,7 +522,19 @@ export async function runOneShot(): Promise<DeepPlanStatus> {
     throw new Error('The generator returned an empty draft. Try again.');
   }
 
-  await writeDocument(target.filename, draft);
+  // Partial-draft rescue: if the stream ended without `[DONE]` (usually a
+  // hosting-platform proxy timeout ~300s), prepend a visible banner so the
+  // user knows the draft was cut off but still gets every token that made
+  // it across — far better than losing 5 minutes of generation entirely.
+  const finalDraft = complete ? draft : prependCutOffBanner(draft);
+  if (!complete) {
+    log('deep-plan', 'oneshot.rescuedPartial', {
+      chars: draft.length,
+      words: countWords(draft),
+    });
+  }
+
+  await writeDocument(target.filename, finalDraft);
 
   await updateSession((s) => ({
     ...s,

--- a/src/main/features/deepPlan/index.ts
+++ b/src/main/features/deepPlan/index.ts
@@ -72,26 +72,26 @@ function estimateTokensK(chars: number): number {
   return chars / 4000;
 }
 
-function countWords(text: string): number {
-  const match = text.trim().match(/\S+/g);
-  return match ? match.length : 0;
-}
+/**
+ * Max follow-up stream requests when the upstream connection drops
+ * mid-generation (managed-backend proxies typically enforce ~300s per
+ * request). Three continuations = up to ~4 total windows of streaming,
+ * which is plenty for even a maximalist one-shot draft.
+ */
+const MAX_CONTINUATIONS = 3;
 
 /**
- * Prefix a partial draft with a visible cut-off banner. Fires when the
- * drafter's stream ends without `[DONE]` — almost always a proxy timeout
- * on the managed backend. Saving the partial (rather than throwing) means
- * the user keeps every token that did stream through, and the banner makes
- * it obvious the draft needs a re-run to finish.
+ * Prompt appended after the partial content to get the model to resume
+ * transparently. Wording matters: some models treat "continue" as a
+ * signal to summarise what they've said; we're explicit that they should
+ * pick up at the exact character and emit zero preamble.
  */
-function prependCutOffBanner(partial: string): string {
-  const words = countWords(partial);
-  const banner =
-    `> ⚠️ **Draft was cut off mid-generation** — ${words} word${words === 1 ? '' : 's'} below. ` +
-    `The upstream stream timed out before the drafter could finish. ` +
-    `Re-run the one-shot to regenerate, or keep editing from here.\n\n---\n\n`;
-  return banner + partial;
-}
+const CONTINUE_INSTRUCTION =
+  'Your previous response was cut off mid-sentence by an upstream timeout — it was NOT finished. ' +
+  'Continue writing from EXACTLY where you stopped: resume the incomplete word or sentence if there is one, ' +
+  'then keep going until the draft is fully complete. ' +
+  'Do NOT repeat any prior content. Do NOT add any preamble, intro, summary, meta-commentary, apology, or acknowledgement. ' +
+  'Do NOT wrap your output in a code block. Emit only the raw markdown that should follow — as if the stream had never paused.';
 
 function appendMessage(
   session: DeepPlanSession,
@@ -503,12 +503,42 @@ export async function runOneShot(): Promise<DeepPlanStatus> {
     promptChars: prompt.length,
   });
 
-  let fullContent = '';
+  // Auto-continue loop. If the upstream stream drops before `[DONE]` (almost
+  // always the managed backend's ~300s proxy timeout biting a long draft),
+  // we replay the original request with the partial content as the prior
+  // assistant turn and ask the model to resume from where it stopped. Chunks
+  // keep broadcasting to the same channel, so from the UI it looks like one
+  // continuous stream — just with a brief pause while we re-establish.
+  let accumulated = '';
   let complete = false;
   try {
-    const result = await streamWithLookupResolution({ model, messages });
-    fullContent = result.content;
-    complete = result.complete;
+    for (let attempt = 0; attempt <= MAX_CONTINUATIONS; attempt++) {
+      const turnMessages: LlmMessage[] =
+        attempt === 0
+          ? messages
+          : [
+              ...messages,
+              { role: 'assistant', content: accumulated },
+              { role: 'user', content: CONTINUE_INSTRUCTION },
+            ];
+      const result = await streamWithLookupResolution({ model, messages: turnMessages });
+      accumulated += result.content;
+      complete = result.complete;
+      if (complete) {
+        if (attempt > 0) {
+          log('deep-plan', 'oneshot.continued', {
+            attempts: attempt,
+            finalChars: accumulated.length,
+          });
+        }
+        break;
+      }
+      log('deep-plan', 'oneshot.autoContinue', {
+        attempt: attempt + 1,
+        max: MAX_CONTINUATIONS,
+        chars: accumulated.length,
+      });
+    }
   } catch (err) {
     logError('deep-plan', 'oneshot.failed', err);
     broadcast(IpcChannels.DeepPlan.ChunkDone);
@@ -517,30 +547,25 @@ export async function runOneShot(): Promise<DeepPlanStatus> {
 
   broadcast(IpcChannels.DeepPlan.ChunkDone);
 
-  const draft = fullContent.trim();
+  if (!complete) {
+    log('deep-plan', 'oneshot.exhaustedContinuations', {
+      chars: accumulated.length,
+      max: MAX_CONTINUATIONS,
+    });
+  }
+
+  const draft = accumulated.trim();
   if (draft.length === 0) {
     throw new Error('The generator returned an empty draft. Try again.');
   }
 
-  // Partial-draft rescue: if the stream ended without `[DONE]` (usually a
-  // hosting-platform proxy timeout ~300s), prepend a visible banner so the
-  // user knows the draft was cut off but still gets every token that made
-  // it across — far better than losing 5 minutes of generation entirely.
-  const finalDraft = complete ? draft : prependCutOffBanner(draft);
-  if (!complete) {
-    log('deep-plan', 'oneshot.rescuedPartial', {
-      chars: draft.length,
-      words: countWords(draft),
-    });
-  }
-
-  await writeDocument(target.filename, finalDraft);
+  await writeDocument(target.filename, draft);
 
   await updateSession((s) => ({
     ...s,
     phase: 'done',
     completed: true,
-    tokensUsedK: s.tokensUsedK + estimateTokensK(prompt.length + fullContent.length),
+    tokensUsedK: s.tokensUsedK + estimateTokensK(prompt.length + accumulated.length),
   }));
   await clearAutoStart();
   broadcast(IpcChannels.Document.Changed);

--- a/src/main/features/deepPlan/panel.ts
+++ b/src/main/features/deepPlan/panel.ts
@@ -152,7 +152,14 @@ async function runOnePanelist(
 
   if (!reply || reply.trim().length === 0) {
     log('deep-plan', 'panel.role.emptyReply', { role });
-    emitProgress({ kind: 'role-done', role, findings: 0, searchQueries: 0 });
+    emitProgress({
+      kind: 'role-done',
+      role,
+      findings: 0,
+      searchQueries: 0,
+      visionNotes: '',
+      needsResearch: [],
+    });
     return { role, visionNotes: '', needsResearch: [] };
   }
 
@@ -160,12 +167,16 @@ async function runOnePanelist(
   emitProgress({
     kind: 'role-done',
     role,
-    // The renderer's progress event shape dates from the old "findings"
-    // era; now that panel is vision-notes + research only, we report
-    // `findings = 1` when the role emitted a non-empty vision note and
-    // `0` when silent. Swap to a dedicated field later if the UI evolves.
+    // `findings` stays as "did this role contribute anything" for the
+    // existing header stats. The actual content streams via
+    // `visionNotes` + `needsResearch` so the renderer can show the
+    // role's thought inline the moment it finishes — users see the
+    // panel's thinking live instead of waiting for the Chair to close
+    // the round.
     findings: output.visionNotes.trim().length > 0 ? 1 : 0,
     searchQueries: output.needsResearch.length,
+    visionNotes: output.visionNotes,
+    needsResearch: output.needsResearch,
   });
   return output;
 }

--- a/src/main/features/deepPlan/panel.ts
+++ b/src/main/features/deepPlan/panel.ts
@@ -253,14 +253,24 @@ export async function runPanelRound(args: PanelRoundArgs): Promise<PanelRoundRes
   );
   const perRoundCap = Math.min(DEEP_PLAN_MAX_SEARCHES_PER_ROUND, remainingBudget);
 
-  // Fan out all panelists in parallel. Individual failures degrade
-  // gracefully to an empty output — the Chair can still synthesise
-  // whatever came back.
-  const panelOutputs = await Promise.all(
-    roles.map((role) =>
-      runOnePanelist(role, args, model, priorFindingsDigest, remainingBudget),
-    ),
-  );
+  // Run panelists with a concurrency cap. Each phase has at most 4 roles
+  // (ideation 3, planning 4, reviewing 4), so a cap of 5 effectively runs
+  // the whole phase in parallel — fastest path when backend rate limits
+  // have headroom. If a 429 does slip through under load, the
+  // `fetchWithRetryOn429` wrapper on every LLM call absorbs it, so we
+  // keep full parallelism here. Drop this back to 2–3 if backend limits
+  // start biting again.
+  const PANEL_CONCURRENCY = 5;
+  const panelOutputs: PanelOutput[] = [];
+  for (let i = 0; i < roles.length; i += PANEL_CONCURRENCY) {
+    const batch = roles.slice(i, i + PANEL_CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map((role) =>
+        runOnePanelist(role, args, model, priorFindingsDigest, remainingBudget),
+      ),
+    );
+    panelOutputs.push(...batchResults);
+  }
 
   const researchRequests = mergeResearchRequests(panelOutputs, perRoundCap);
   const newlyIngestedSourceSlugs = await dispatchPanelResearch(researchRequests);

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -431,15 +431,18 @@ ${priorSummaries ? `Prior-round Chair summaries (do NOT repeat these — move th
 }
 
 VISION.md rules:
-- Vision is SMALL. Target 200–800 words. Dot-points, not prose. The upper cap is 1500 words — past that you're drifting into plan-rewrite territory.
+- **Vision is the most important artefact in the session.** It carries the NOVEL IDEAS, the thesis, the POV, the angle the writer + you have landed on. Everything else (panel, anchors, drafter) serves it. Not a structure planner, not an outline — an idea document.
+- Vision is SMALL. Target 200–800 words. Dot-points, not prose. Hard cap at 1500 words — past that you're drifting into plan-rewrite territory.
 - Vision carries IDEAS, not citations. No \`([Name](slug.md#...))\` references inside vision. No blockquotes. No long paragraphs. Citations live in the anchor log; vision tells the drafter WHAT to do with them.
-- Good vision sections: "Thesis", "POV / angle", "Structure" (see below — always present), "Section intents" (bullet per section with a one-line intent + short labels for the 1–3 key anchors it leans on — e.g. "the Sen's theorem claim", not by \`#id\`), "Novel insights surfaced in conversation", "Counter-argument to engage", "What this piece is NOT".
-- **Structure is mandatory in the vision.** The drafter otherwise ships unstructured walls of prose. Your vision MUST include a "Structure" section with:
-  - The opening move (how the piece starts — a hook, a scene, a claim)
-  - An ordered list of 3–6 H2 section titles the drafter will use (for a standard essay). Blog posts may have 2–4; reports may have 5–8. The form in the rubric drives the count.
-  - A one-line intent per section title.
-  - The closing move (how the piece lands — synthesis, call-forward, specific claim).
-  - Example shape for a 2000-word essay: \`## The decomposition that gets cited\` / \`## Where the math stops being enough\` / \`## AI alignment as the modern test case\` / \`## What Pareto can and cannot do\`.
+- **Keep the formatting LIGHT.** One H1 for the piece's working title. Flat bold labels (e.g. \`**Thesis:**\`) and bullets underneath them, NOT a cascade of H2s/H3s turning vision into a mini-plan.md. Markdown heading hierarchy should feel invisible; the ideas should be the star.
+- What belongs in vision, roughly in priority order:
+  1. **Thesis** — the single claim the piece makes, one or two sentences.
+  2. **POV / angle** — the lens. Why THIS take, not a textbook summary?
+  3. **Novel insights** — the ideas the writer + Chair surfaced in conversation that don't live in any one source. The core of the piece.
+  4. **Counter-argument to engage** — the strongest opposing position, stated in one line.
+  5. **What this piece is NOT** — scope-setting; what you deliberately chose to leave out.
+  6. **Section arc** *(light touch, not a heading outline)* — a single line or brief bullet list naming 3–6 beats in reading order, phrased as intents ("open with the decomposition", "pivot to the distributional critique", "land on what the concept can and cannot do"). This seeds the drafter's H2s; the drafter writes the actual section titles at draft time.
+- The section arc is one line in the vision, not its own major section with sub-bullets. If you find yourself writing more than a line per beat, you're drifting into plan-rewrite territory.
 - \`visionUpdate: null\` is the right call on rounds where nothing substantive shifted. Don't rewrite vision just to rewrite it — small churn is noise.
 - When you DO rewrite vision, you're rewriting the WHOLE thing in full (no patches). Preserve what still holds; sharpen what just moved.
 
@@ -712,8 +715,7 @@ References section (required, end of draft) — HARVARD STYLE:
 
 Structure + headings (mandatory — draft gets rejected without them):
 - **Open with a \`# Title\` H1.** Never ship a draft with no title line. Pick a title that names the piece's actual angle, not a generic restatement of the task.
-- **Use H2 section headings (\`## Section title\`) to break the body into its thread arc.** The vision's "Structure" section names the exact H2s you should use; follow them. If the vision lists four H2 titles, your draft uses four H2 sections.
-- When the vision is missing an explicit structure list, derive H2s yourself from the form + content:
+- **Use H2 section headings (\`## Section title\`) to break the body into its thread arc.** Derive the H2s from the vision's section-arc line (the brief intents it lists: "open with X", "pivot to Y", "land on Z") + the form — you pick the actual H2 titles, not the vision.
   - **Essay (1500–2500 words)**: 3–6 H2 sections. Never one continuous flow.
   - **Blog post (800–1500 words)**: 2–4 H2 sections.
   - **Op-ed (800–1500 words)**: usually 2–4 H2s, sometimes 1 if the argument is tightly linear.

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -699,19 +699,20 @@ References section (required, end of draft) — HARVARD STYLE:
 - \`## References\` heading (sentence case, no variations).
 - List every unique slug actually cited in the body, once each. ONE bullet per source.
 - Harvard format, per entry:
-  \`- Author (Year) *Title*. Publisher or outlet. Available at: URL. [[source](slug.md)]\`
+  \`- Author (Year) *Title*. Publisher or outlet. [[web](https://…)] [[source](slug.md)]\`
   - **Author**: surname(s), full initial(s). "Sen, A." / "Smith, J. and Jones, K." Institutional source: full name — "Stanford Encyclopedia of Philosophy", "Federal Reserve Bank of Richmond".
   - **(Year)**: in parentheses immediately after the author. If truly unknown, use \`(n.d.)\`.
   - **Title** in italics. Preserve the original capitalisation from the source.
   - **Publisher / outlet** if identifiable (journal name, news outlet, publisher, institution).
-  - **Available at: URL.** — include the URL if the anchor entry shows a source URL. Drop the "Available at" clause when no URL.
-  - **Trailing \`[[source](slug.md)]\`** — this is the Myst-internal link to the source wiki page; ALWAYS include it as the last element of each bullet so the reference remains clickable inside the app.
+  - **\`[[web](URL)]\`** — clickable link to the original website the source lives on. Take the URL from the anchor entry (the anchor list's "source URL" or, failing that, the URL visible in the anchor text / summary). Include this ONLY when you have a real URL; do not invent one.
+  - **\`[[source](slug.md)]\`** — ALWAYS the final element: the Myst-internal link to the source's wiki page, so the reference stays clickable inside the app even when the original URL is paywalled / dead / missing.
+- Both links go inside double square brackets so they render as distinct link-chip tails rather than dissolving into the prose. \`[web]\` first, \`[source]\` last.
 - Examples:
-  - \`- Sen, A. (1970) *The Impossibility of a Paretian Liberal*. Journal of Political Economy. Available at: https://www.jstor.org/stable/1829989. [[source](sen-1970.md)]\`
-  - \`- Stanford Encyclopedia of Philosophy (2018) *Pareto Efficiency*. Available at: https://plato.stanford.edu/entries/pareto/. [[source](pareto-efficiency.md)]\`
-  - \`- Richmond Fed (2011) *Efficient Rent Seeking*. Federal Reserve Bank of Richmond. [[source](richmond-feldstein.md)]\`
+  - \`- Sen, A. (1970) *The Impossibility of a Paretian Liberal*. Journal of Political Economy. [[web](https://www.jstor.org/stable/1829989)] [[source](sen-1970.md)]\`
+  - \`- Stanford Encyclopedia of Philosophy (2018) *Pareto Efficiency*. [[web](https://plato.stanford.edu/entries/pareto/)] [[source](pareto-efficiency.md)]\`
+  - \`- Richmond Fed (2011) *Efficient Rent Seeking*. Federal Reserve Bank of Richmond. [[source](richmond-feldstein.md)]\` *(no URL available; web chip omitted)*
 - Alphabetise by author surname (or institution name when author-less). One bullet per source. Do NOT list sources you didn't cite in the body. Do NOT duplicate.
-- Infer metadata from the anchor log entries — each anchor shows its source name, and many anchor texts or URLs reveal year / publisher. If a field is genuinely unrecoverable, omit it rather than invent. The ONE required element you must never skip is the trailing \`[[source](slug.md)]\`.
+- Infer metadata from the anchor log entries — each anchor shows its source name + URL, and many anchor texts reveal year / publisher. If a field is genuinely unrecoverable, omit it rather than invent. The ONE required element you must never skip is the trailing \`[[source](slug.md)]\` chip.
 
 Structure + headings (mandatory — draft gets rejected without them):
 - **Open with a \`# Title\` H1.** Never ship a draft with no title line. Pick a title that names the piece's actual angle, not a generic restatement of the task.

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -433,7 +433,13 @@ ${priorSummaries ? `Prior-round Chair summaries (do NOT repeat these — move th
 VISION.md rules:
 - Vision is SMALL. Target 200–800 words. Dot-points, not prose. The upper cap is 1500 words — past that you're drifting into plan-rewrite territory.
 - Vision carries IDEAS, not citations. No \`([Name](slug.md#...))\` references inside vision. No blockquotes. No long paragraphs. Citations live in the anchor log; vision tells the drafter WHAT to do with them.
-- Good vision sections: "Thesis", "POV / angle", "Section intents" (bullet per section with a one-line intent + short labels for the 1–3 key anchors it leans on — e.g. "the Sen's theorem claim", not by \`#id\`), "Novel insights surfaced in conversation", "Counter-argument to engage", "What this piece is NOT".
+- Good vision sections: "Thesis", "POV / angle", "Structure" (see below — always present), "Section intents" (bullet per section with a one-line intent + short labels for the 1–3 key anchors it leans on — e.g. "the Sen's theorem claim", not by \`#id\`), "Novel insights surfaced in conversation", "Counter-argument to engage", "What this piece is NOT".
+- **Structure is mandatory in the vision.** The drafter otherwise ships unstructured walls of prose. Your vision MUST include a "Structure" section with:
+  - The opening move (how the piece starts — a hook, a scene, a claim)
+  - An ordered list of 3–6 H2 section titles the drafter will use (for a standard essay). Blog posts may have 2–4; reports may have 5–8. The form in the rubric drives the count.
+  - A one-line intent per section title.
+  - The closing move (how the piece lands — synthesis, call-forward, specific claim).
+  - Example shape for a 2000-word essay: \`## The decomposition that gets cited\` / \`## Where the math stops being enough\` / \`## AI alignment as the modern test case\` / \`## What Pareto can and cannot do\`.
 - \`visionUpdate: null\` is the right call on rounds where nothing substantive shifted. Don't rewrite vision just to rewrite it — small churn is noise.
 - When you DO rewrite vision, you're rewriting the WHOLE thing in full (no patches). Preserve what still holds; sharpen what just moved.
 
@@ -638,6 +644,8 @@ export function oneShotPrompt(
 
 5. **HONOUR THE WORD-COUNT RANGE** in the rubric. Going over or under by more than 10% is a failure.
 
+6. **STRUCTURE WITH HEADINGS.** Every draft opens with a \`# Title\` H1 and breaks the body into \`## Section\` H2s that follow the vision's "Structure" section (when present) or derive from the form (3–6 H2s for a standard essay, 2–4 for a blog/op-ed, 5–8 for a report). Section titles tell the reader what the section ARGUES, not just what topic it covers. A wall of unbroken prose with no H2s is a shipping failure — full details in the "Structure + headings" block below.
+
 You are Myst, writing the first full draft of "${docLabel}" from a completed Deep Plan session. You are an essayist with an evidence bundle. The VISION is the intellectual spine (thesis, POV, section intents). The ANCHOR LOG is the evidence pile. Your job: turn the vision into finished analytical prose, grounded by the anchors, paraphrased naturally in your own voice.
 
 User's task: "${session.task}"
@@ -702,10 +710,22 @@ References section (required, end of draft) — HARVARD STYLE:
 - Alphabetise by author surname (or institution name when author-less). One bullet per source. Do NOT list sources you didn't cite in the body. Do NOT duplicate.
 - Infer metadata from the anchor log entries — each anchor shows its source name, and many anchor texts or URLs reveal year / publisher. If a field is genuinely unrecoverable, omit it rather than invent. The ONE required element you must never skip is the trailing \`[[source](slug.md)]\`.
 
+Structure + headings (mandatory — draft gets rejected without them):
+- **Open with a \`# Title\` H1.** Never ship a draft with no title line. Pick a title that names the piece's actual angle, not a generic restatement of the task.
+- **Use H2 section headings (\`## Section title\`) to break the body into its thread arc.** The vision's "Structure" section names the exact H2s you should use; follow them. If the vision lists four H2 titles, your draft uses four H2 sections.
+- When the vision is missing an explicit structure list, derive H2s yourself from the form + content:
+  - **Essay (1500–2500 words)**: 3–6 H2 sections. Never one continuous flow.
+  - **Blog post (800–1500 words)**: 2–4 H2 sections.
+  - **Op-ed (800–1500 words)**: usually 2–4 H2s, sometimes 1 if the argument is tightly linear.
+  - **Report (2500+ words)**: 5–8 H2 sections, often with H3 sub-sections.
+- Section titles do the work — they should tell a reader what the section argues, not just what topic it covers. "The decomposition that gets cited" beats "Background".
+- **References is its own \`## References\` H2 at the end.** Not in the body flow; always the final section.
+- H3+ sub-headings are allowed for long/structured pieces (reports especially) but optional for essays.
+
 Form + output rules:
 - Hit the rubric — length, form, audience.
-- No preamble, no "Here is your draft:", no meta-commentary. Start with the title or opening line and write straight through.
-- Use proper markdown: \`#\` headings, \`**bold**\`, \`*italic*\`, blank lines between paragraphs.
+- No preamble, no "Here is your draft:", no meta-commentary. Start with the H1 title line and write straight through.
+- Use proper markdown: \`#\` title, \`## Section\` H2s, \`**bold**\`, \`*italic*\`, blank lines between paragraphs.
 
 Output: the complete markdown draft, nothing else.
 

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -450,6 +450,7 @@ Question rules:
 - **FIRST PRIORITY — missing hard requirements.** If the rubric above lists any field as "(not specified)" (especially word count), ask about them THIS ROUND. Use \`choice\` with 3–4 reasonable defaults and mark one \`recommended\`. Example for word count: {1000–1500, 1500–2500, 2500–4000, custom with \`allowCustom: true\`}.
 - At most ${DEEP_PLAN_MAX_QUESTIONS_PER_ROUND} questions. Once requirements are complete, the user has delegated — ASK ONLY when a judgment call genuinely needs them (a thesis fork, a scope trade-off, a framing they haven't signalled). Empty array is often the right answer.
 - Prefer \`choice\` > \`confirm\` > \`multi\` > \`open\`. Mark ONE choice \`recommended\` when there's a defensible default. Set \`allowCustom: true\` when the options don't exhaust the space.
+- **NEVER ask a "ready to advance to the next phase?" or "shall we move on?" question via the question card.** The UI has its own phase-advance CTA the user can hit whenever they want. If you think the phase is ready to close, set \`phaseAdvance: true\` AND mention it conversationally in your \`summary\` (e.g. "I think we're ready for planning — hit Continue when you are, or keep chatting if there's more to work through."). Never split that decision across a question card — you end up with a phantom answer recorded in the transcript while the phase doesn't actually advance.
 
 phaseAdvance rule:
 - NEVER \`true\` while any hard requirement (word count, form, audience) is still "(not specified)".

--- a/src/main/features/research/credibility.ts
+++ b/src/main/features/research/credibility.ts
@@ -58,6 +58,14 @@ const BLOCKED_HOSTS: readonly string[] = [
   'chegg.com',
   'coursehero.com',
   'studocu.com',
+  // Video platforms — we can't ingest video. Transcripts, if available,
+  // are better sourced from a published transcript page, not the video
+  // URL itself.
+  'youtube.com',
+  'youtu.be',
+  'vimeo.com',
+  'rumble.com',
+  'dailymotion.com',
   // Link shorteners — we want the resolved URL, not the redirect.
   'bit.ly',
   't.co',
@@ -102,7 +110,7 @@ PRIMARY > SECONDARY > TERTIARY:
 - Primary (the original claim/research/dataset) beats secondary (someone summarising it) beats tertiary (a summary of a summary). When a concept has a named originator or landmark paper, put that name in the query — "arrow impossibility theorem 1951" pulls the primary literature; "pareto efficiency explained" pulls Investopedia.
 - If the wiki already has 2+ sources on a concept, do NOT search for another one. Pivot to an adjacent concept, a primary-source author, or a contested angle.
 
-Hard-blocked hosts (rejected at fetch time, so queries that would return them waste budget): tiktok, instagram, facebook, twitter/x, threads, snapchat, reddit, quora, pinterest, 4chan, linkedin, amazon, ebay, etsy, alibaba, aliexpress, temu, shein, walmart, target, bestbuy, chegg, coursehero, studocu, and link shorteners.`;
+Hard-blocked hosts (rejected at fetch time, so queries that would return them waste budget): tiktok, instagram, facebook, twitter/x, threads, snapchat, reddit, quora, pinterest, 4chan, linkedin, amazon, ebay, etsy, alibaba, aliexpress, temu, shein, walmart, target, bestbuy, chegg, coursehero, studocu, youtube, youtu.be, vimeo, rumble, dailymotion, and link shorteners. We cannot ingest video — if a video is the primary source, find the published transcript or a written follow-up instead.`;
 
 function normaliseHost(host: string): string {
   return host.toLowerCase().replace(/^www\./, '').trim();

--- a/src/main/features/research/credibility.ts
+++ b/src/main/features/research/credibility.ts
@@ -37,6 +37,27 @@ const BLOCKED_HOSTS: readonly string[] = [
   '4chan.org',
   // Professional networking timelines.
   'linkedin.com',
+  // Commercial / product listings — landing pages, not source material.
+  // An Amazon product page or eBay listing is not a thing you cite.
+  'amazon.com',
+  'amazon.co.uk',
+  'amazon.ca',
+  'amazon.de',
+  'amazon.fr',
+  'amazon.co.jp',
+  'ebay.com',
+  'etsy.com',
+  'alibaba.com',
+  'aliexpress.com',
+  'temu.com',
+  'shein.com',
+  'walmart.com',
+  'target.com',
+  'bestbuy.com',
+  // Q&A + homework content farms, mostly user-generated junk.
+  'chegg.com',
+  'coursehero.com',
+  'studocu.com',
   // Link shorteners — we want the resolved URL, not the redirect.
   'bit.ly',
   't.co',
@@ -59,19 +80,29 @@ export interface CredibilityVerdict {
  */
 export const PREFERRED_SOURCE_HINT = `SOURCE QUALITY — this is load-bearing. The wiki's value is proportional to the strength of its sources, and search is the lever you control.
 
-PREFER (in rough priority order):
-1. Primary academic literature: arxiv.org, journal papers (nature.com, science.org, jstor.org, springer.com, sciencedirect.com), author working papers at *.edu, SSRN.
-2. Reference works written by subject-matter editors: stanford encyclopedia of philosophy (plato.stanford.edu), wikipedia, iep.utm.edu.
-3. Reputable news with editorial standards: reuters.com, apnews.com, ft.com, nytimes.com, economist.com, bbc.co.uk, wsj.com.
-4. Official sources: *.gov, *.who.int, *.oecd.org, central-bank publications (bis.org, federalreserve.gov), world-bank.org.
-5. Established long-form analysis: theatlantic.com, newyorker.com, nybooks.com, aeon.co.
+SOURCE TYPES to focus on (think in categories, not URLs):
+- **Research papers** — peer-reviewed journal articles, working papers, preprints.
+- **Journal articles** — academic journals, domain-specific publications.
+- **News articles** — reporting from outlets with editorial standards (Reuters, AP, FT, NYT, Economist, BBC, WSJ, Guardian).
+- **Long-form analysis / essays** — The Atlantic, New Yorker, NYBooks, Aeon.
+- **Reference works** — Wikipedia, Stanford Encyclopedia of Philosophy, IEP, domain encyclopedias, official documentation.
+- **Government / institutional reports** — *.gov, WHO, OECD, World Bank, central banks.
+- **Expert blogs / Substack** — only when the author is a recognised subject-matter authority with a verifiable track record (e.g. a domain expert's personal blog, a named researcher's Substack). NOT random "top 10" blogs.
+- **Books + book chapters** — when excerpts, reviews, or publisher pages with substantive content are available online.
 
-AVOID (these are "technically on-topic" but thin):
-- Explainer / SEO content farms: Investopedia, Corporate Finance Institute, "XYZ Explained" sites, "Ultimate guide to ..." listicles, wikiHow. The wiki does NOT need a 4th generic summary of a well-understood concept — one Wikipedia entry plus one primary source beats five SEO explainers. If the query is shaped in a way that would naturally return these, reshape it.
-- Shape queries to return primary material, not summaries. "pareto efficiency explained" pulls Investopedia; "arrow impossibility theorem 1951" pulls the primary literature. When the concept has a named originator or landmark paper, put that name in the query.
-- If the wiki already has 2+ sources on a given concept, do NOT search for another one — pivot to an adjacent concept, a primary-source author, or a contested angle instead. Diminishing returns set in fast.
+NEVER use as a source (these are landing pages, not material to cite):
+- **Product / commercial listings** — Amazon pages, eBay listings, Etsy, retailer product pages. A book's Amazon page is NOT a source for that book's ideas; find the book's text, a review, or the publisher page.
+- **Forums & Q&A** — Reddit threads, Quora answers, Chegg, Course Hero, StackExchange answers (use the original paper/docs the answer links to instead).
+- **Social media** — TikTok, Instagram, Twitter/X, Facebook, LinkedIn posts. Even "expert" social-media posts are hard to cite precisely.
+- **Short-form explainer farms** — Investopedia, Corporate Finance Institute, wikiHow, "Ultimate Guide to X" listicles. One Wikipedia entry + one primary source beats five SEO explainers.
+- **Marketing / landing pages** — SaaS product pages, course-sales pages, conference home pages. These describe a thing, they don't analyse it.
+- **News aggregators without original content** — Google News result pages, RSS aggregators.
 
-Hard-blocked domains (tiktok, reddit, linkedin, quora, pinterest, facebook, instagram, twitter/x, snapchat, 4chan, link shorteners) are rejected at fetch time, so queries that would return them waste a search budget slot.`;
+PRIMARY > SECONDARY > TERTIARY:
+- Primary (the original claim/research/dataset) beats secondary (someone summarising it) beats tertiary (a summary of a summary). When a concept has a named originator or landmark paper, put that name in the query — "arrow impossibility theorem 1951" pulls the primary literature; "pareto efficiency explained" pulls Investopedia.
+- If the wiki already has 2+ sources on a concept, do NOT search for another one. Pivot to an adjacent concept, a primary-source author, or a contested angle.
+
+Hard-blocked hosts (rejected at fetch time, so queries that would return them waste budget): tiktok, instagram, facebook, twitter/x, threads, snapchat, reddit, quora, pinterest, 4chan, linkedin, amazon, ebay, etsy, alibaba, aliexpress, temu, shein, walmart, target, bestbuy, chegg, coursehero, studocu, and link shorteners.`;
 
 function normaliseHost(host: string): string {
   return host.toLowerCase().replace(/^www\./, '').trim();

--- a/src/main/features/research/fetch.ts
+++ b/src/main/features/research/fetch.ts
@@ -5,6 +5,7 @@ import { log, logError } from '../../platform';
 import { getAuthTokenSync, invalidateToken } from '../auth';
 import { refreshAfterRequest } from '../me';
 import { getJinaKey } from '../settings';
+import { fetchWithRetryOn429 } from '../../llm/openmyst';
 import { checkSourceAllowed } from './credibility';
 
 /**
@@ -78,16 +79,20 @@ async function openmystFetch(url: string): Promise<FetchedPage> {
 
   log('sources', 'fetchUrl.openmyst.request', { url });
 
-  const response = await fetch(`${OPENMYST_API_BASE_URL}/api/v1/fetch`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      'User-Agent': `openmyst-desktop/${version} (${platform()}-${arch()})`,
-      'X-Client-Version': version,
-    },
-    body: JSON.stringify({ url }),
-  });
+  const response = await fetchWithRetryOn429(
+    () =>
+      fetch(`${OPENMYST_API_BASE_URL}/api/v1/fetch`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': `openmyst-desktop/${version} (${platform()}-${arch()})`,
+          'X-Client-Version': version,
+        },
+        body: JSON.stringify({ url }),
+      }),
+    { logScope: 'sources' },
+  );
 
   if (!response.ok) {
     const text = await response.text().catch(() => '');

--- a/src/main/features/settings/index.ts
+++ b/src/main/features/settings/index.ts
@@ -21,6 +21,18 @@ import {
  * cipher as base64 inside the same JSON; the plaintext never touches disk.
  */
 
+/**
+ * Bump this when you want every existing user's model slots force-reset to
+ * the current DEFAULT_* values on next app launch. Used to roll out new
+ * model defaults without leaving users stuck on whatever they'd manually
+ * configured. The reset runs once per bump — subsequent reads see the
+ * updated version and skip.
+ *
+ *   v1 — 2026-04: reset to gemma-4-31b-it + gemini-2.5-flash-lite defaults
+ *        after the panel/summary/chair/draft slot split landed.
+ */
+const CURRENT_MODEL_DEFAULTS_VERSION = 1;
+
 interface StoredSettings {
   defaultModel: string;
   /**
@@ -35,6 +47,13 @@ interface StoredSettings {
   draftModel: string;
   panelModel: string;
   summaryModel: string;
+  /**
+   * Last defaults-version applied for this user. When lower than
+   * CURRENT_MODEL_DEFAULTS_VERSION, the five model slots above get
+   * force-reset to DEFAULT_* on next read. 0 = never applied (fresh
+   * users + anyone whose settings predate the field).
+   */
+  modelDefaultsVersion: number;
   openRouterKeyCipher: string | null;
   jinaKeyCipher: string | null;
   recentProjects: string[];
@@ -48,6 +67,7 @@ const DEFAULTS: StoredSettings = {
   draftModel: DEFAULT_DRAFT_MODEL,
   panelModel: DEFAULT_PANEL_MODEL,
   summaryModel: DEFAULT_SUMMARY_MODEL,
+  modelDefaultsVersion: CURRENT_MODEL_DEFAULTS_VERSION,
   openRouterKeyCipher: null,
   jinaKeyCipher: null,
   recentProjects: [],
@@ -74,11 +94,14 @@ async function readStored(): Promise<StoredSettings> {
   try {
     const raw = await fs.readFile(settingsPath(), 'utf-8');
     const parsed = JSON.parse(raw) as Partial<StoredSettings>;
+    const migrated: StoredSettings = { ...DEFAULTS, ...parsed };
+
     // Phase-1 migration: if the user's settings predate chair/draft split,
     // carry their prior `deepPlanModel` forward into both new slots so the
-    // upgrade is invisible. They can then point chairModel at gpt-oss-120b
-    // (the new default) on their own schedule via the settings UI.
-    const migrated: StoredSettings = { ...DEFAULTS, ...parsed };
+    // upgrade is invisible. (Only matters for existing users on bumps
+    // below CURRENT_MODEL_DEFAULTS_VERSION; the force-reset below will
+    // overwrite these anyway on the initial rollout, but the soft-copy
+    // keeps things sane if someone hand-edits settings.json.)
     if (parsed.chairModel === undefined && typeof parsed.deepPlanModel === 'string') {
       migrated.chairModel = parsed.deepPlanModel;
     }
@@ -86,11 +109,33 @@ async function readStored(): Promise<StoredSettings> {
       migrated.draftModel = parsed.deepPlanModel;
     }
     // Split panel model out from summary model for existing users — their
-    // panel previously shared summaryModel, so copy the current value
-    // forward so behavior doesn't flip on upgrade.
+    // panel previously shared summaryModel.
     if (parsed.panelModel === undefined && typeof parsed.summaryModel === 'string') {
       migrated.panelModel = parsed.summaryModel;
     }
+
+    // Force-reset model slots on defaults-version bump. Triggered for
+    // users whose stored version is older than CURRENT — typically right
+    // after they install an app update that declared new defaults. Runs
+    // exactly once: we write the new version back immediately so
+    // subsequent reads skip the branch.
+    const storedDefaultsVersion =
+      typeof parsed.modelDefaultsVersion === 'number' ? parsed.modelDefaultsVersion : 0;
+    if (storedDefaultsVersion < CURRENT_MODEL_DEFAULTS_VERSION) {
+      migrated.defaultModel = DEFAULT_MODEL;
+      migrated.deepPlanModel = DEFAULT_DEEP_PLAN_MODEL;
+      migrated.chairModel = DEFAULT_CHAIR_MODEL;
+      migrated.draftModel = DEFAULT_DRAFT_MODEL;
+      migrated.panelModel = DEFAULT_PANEL_MODEL;
+      migrated.summaryModel = DEFAULT_SUMMARY_MODEL;
+      migrated.modelDefaultsVersion = CURRENT_MODEL_DEFAULTS_VERSION;
+      // Persist the reset so the next read doesn't repeat it. Fire-and-
+      // forget; a failure here just means we try again next launch.
+      void writeStored(migrated).catch(() => {
+        /* ignore — non-fatal */
+      });
+    }
+
     return migrated;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { ...DEFAULTS };

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -3,7 +3,7 @@ import { getAuthTokenSync } from '../features/auth';
 import { getOpenRouterKey, getSettings } from '../features/settings';
 import { openrouterCompleteText, openrouterStreamChat } from './openrouter';
 import { openmystCompleteText, openmystStreamChat } from './openmyst';
-import type { CompleteTextOptions, StreamChatOptions } from './types';
+import type { CompleteTextOptions, StreamChatOptions, StreamChatResult } from './types';
 
 /**
  * LLM facade. Every feature that needs a completion imports from here, not
@@ -41,7 +41,7 @@ export async function ensureLlmReady(): Promise<void> {
   if (!key) throw new Error('OpenRouter API key not set. Add it in Settings.');
 }
 
-export async function streamChat(options: StreamChatOptions): Promise<string> {
+export async function streamChat(options: StreamChatOptions): Promise<StreamChatResult> {
   if (USE_OPENMYST) {
     const token = getAuthTokenSync();
     if (!token) throw new Error('Sign in to use Open Myst.');

--- a/src/main/llm/openmyst.ts
+++ b/src/main/llm/openmyst.ts
@@ -72,6 +72,78 @@ function buildHeaders(token: string): Record<string, string> {
   };
 }
 
+/**
+ * Wrap a fetch-producing thunk with 429 retry. The openmyst backend enforces
+ * a sliding rate limit per user — when it fires, parallel panel + research
+ * fetches cascade into the same cooldown window and the whole round fails
+ * silently. This helper:
+ *   - retries up to `maxAttempts` times on 429 (default 3, i.e. 2 retries)
+ *   - respects the `Retry-After` header when present
+ *   - falls back to parsing `"Try again in Xs"` out of the JSON body when
+ *     the backend doesn't set a header (openmyst's current behaviour)
+ *   - caps waits at 30s so we never pause the UI forever
+ *   - consumes the response body when it's a retryable 429 (otherwise the
+ *     connection stays half-open and we can't re-hit the same URL cleanly)
+ *
+ * Caller is responsible for processing the final `Response` — we only retry
+ * the request, we do NOT read the body on success.
+ */
+export async function fetchWithRetryOn429(
+  request: () => Promise<Response>,
+  opts: { maxAttempts?: number; logScope?: string } = {},
+): Promise<Response> {
+  const maxAttempts = Math.max(1, opts.maxAttempts ?? 3);
+  const logScope = opts.logScope ?? 'llm';
+  let lastBody = '';
+  let lastStatus = 429;
+  let lastHeaders: Headers | null = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const response = await request();
+    if (response.status !== 429) return response;
+    // Read the body so we can re-issue the request on the same connection
+    // cleanly AND extract the "Try again in Xs" hint from the JSON body.
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      /* ignore body read failure; fall back to header hint */
+    }
+    lastBody = body;
+    lastStatus = response.status;
+    lastHeaders = response.headers;
+
+    const headerHint = response.headers.get('Retry-After');
+    let waitSec = headerHint ? Number.parseInt(headerHint, 10) : Number.NaN;
+    if (Number.isNaN(waitSec)) {
+      const match = body.match(/Try again in (\d+)\s*s/i);
+      if (match) waitSec = Number.parseInt(match[1]!, 10);
+    }
+    if (Number.isNaN(waitSec) || waitSec <= 0) waitSec = 5;
+    const waitMs = Math.min(waitSec * 1000, 30_000);
+
+    if (attempt === maxAttempts) {
+      // Give up — reconstitute a Response with the body we consumed so
+      // callers' normal error-parsing code path works uniformly.
+      return new Response(body, {
+        status: lastStatus,
+        headers: lastHeaders ?? undefined,
+      });
+    }
+
+    log(logScope, 'openmyst.rateLimit.retry', {
+      attempt,
+      maxAttempts,
+      waitSec,
+      status: lastStatus,
+    });
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+  }
+
+  // Unreachable — the loop always either returns or exhausts maxAttempts.
+  return new Response(lastBody, { status: lastStatus, headers: lastHeaders ?? undefined });
+}
+
 async function parseErrorResponse(response: Response): Promise<OpenmystApiError> {
   let body: OpenmystErrorBody = {};
   const retryAfterHeader = response.headers.get('Retry-After');
@@ -138,11 +210,15 @@ export async function openmystStreamChat(options: {
   if (options.temperature !== undefined) body['temperature'] = options.temperature;
   if (options.maxTokens !== undefined) body['max_tokens'] = options.maxTokens;
 
-  const response = await fetch(`${OPENMYST_API_BASE_URL}/api/v1/chat`, {
-    method: 'POST',
-    headers: buildHeaders(token),
-    body: JSON.stringify(body),
-  });
+  const response = await fetchWithRetryOn429(
+    () =>
+      fetch(`${OPENMYST_API_BASE_URL}/api/v1/chat`, {
+        method: 'POST',
+        headers: buildHeaders(token),
+        body: JSON.stringify(body),
+      }),
+    { logScope },
+  );
 
   if (!response.ok) {
     const err = await parseErrorResponse(response);
@@ -244,11 +320,15 @@ export async function openmystCompleteText(options: {
   if (options.maxTokens !== undefined) body['max_tokens'] = options.maxTokens;
 
   try {
-    const response = await fetch(`${OPENMYST_API_BASE_URL}/api/v1/chat`, {
-      method: 'POST',
-      headers: buildHeaders(token),
-      body: JSON.stringify(body),
-    });
+    const response = await fetchWithRetryOn429(
+      () =>
+        fetch(`${OPENMYST_API_BASE_URL}/api/v1/chat`, {
+          method: 'POST',
+          headers: buildHeaders(token),
+          body: JSON.stringify(body),
+        }),
+      { logScope },
+    );
 
     if (!response.ok) {
       const err = await parseErrorResponse(response);

--- a/src/main/llm/openmyst.ts
+++ b/src/main/llm/openmyst.ts
@@ -4,7 +4,7 @@ import { OPENMYST_API_BASE_URL } from '@shared/flags';
 import { log, logError } from '../platform';
 import { invalidateToken } from '../features/auth';
 import { refreshAfterRequest } from '../features/me';
-import type { LlmMessage } from './types';
+import type { LlmMessage, StreamChatResult } from './types';
 
 /**
  * Managed-mode LLM client. Talks to `POST /api/v1/chat` on openmyst.ai using
@@ -189,7 +189,7 @@ export async function openmystStreamChat(options: {
   logScope?: string;
   temperature?: number;
   maxTokens?: number;
-}): Promise<string> {
+}): Promise<StreamChatResult> {
   const { token, messages, model, onChunk, logScope = 'llm' } = options;
 
   const totalChars = messages.reduce((sum, m) => sum + m.content.length, 0);
@@ -290,13 +290,15 @@ export async function openmystStreamChat(options: {
     preview: fullContent.slice(0, 400),
   });
 
-  // Per contract §5, a dropped stream ends without `[DONE]`. Let the caller
-  // decide whether to display whatever arrived with an "interrupted" marker.
+  // Per contract §5, a dropped stream ends without `[DONE]`. We return
+  // the partial content + `complete: false` so callers (the drafter
+  // especially) can surface a "cut off" marker and save what got
+  // generated rather than losing 5 minutes of tokens to a proxy timeout.
   if (!sawDone && fullContent.length > 0) {
     log(logScope, 'openmyst.llm.streamIncomplete', { chars: fullContent.length });
   }
   refreshAfterRequest();
-  return fullContent;
+  return { content: fullContent, complete: sawDone };
 }
 
 /**

--- a/src/main/llm/openrouter.ts
+++ b/src/main/llm/openrouter.ts
@@ -1,5 +1,5 @@
 import { log, logError } from '../platform';
-import type { LlmMessage, StreamChatOptions } from './types';
+import type { LlmMessage, StreamChatOptions, StreamChatResult } from './types';
 
 /**
  * Single source of truth for talking to OpenRouter. Every feature that calls
@@ -51,7 +51,7 @@ export async function openrouterStreamChat(options: {
   messages: StreamChatOptions['messages'];
   onChunk?: StreamChatOptions['onChunk'];
   logScope?: StreamChatOptions['logScope'];
-}): Promise<string> {
+}): Promise<StreamChatResult> {
   const { apiKey, model, messages, onChunk, logScope = 'llm' } = options;
 
   const totalChars = messages.reduce((sum, m) => sum + m.content.length, 0);
@@ -83,6 +83,7 @@ export async function openrouterStreamChat(options: {
   let fullContent = '';
   let buffer = '';
   let reading = true;
+  let sawDone = false;
 
   while (reading) {
     const { done, value } = await reader.read();
@@ -99,7 +100,10 @@ export async function openrouterStreamChat(options: {
       const trimmed = line.trim();
       if (!trimmed || !trimmed.startsWith('data: ')) continue;
       const data = trimmed.slice(6);
-      if (data === '[DONE]') continue;
+      if (data === '[DONE]') {
+        sawDone = true;
+        continue;
+      }
 
       try {
         const parsed = JSON.parse(data) as {
@@ -119,9 +123,13 @@ export async function openrouterStreamChat(options: {
   log(logScope, 'llm.response', {
     chars: fullContent.length,
     elapsedMs: Date.now() - t0,
+    sawDone,
     preview: fullContent.slice(0, 400),
   });
-  return fullContent;
+  if (!sawDone && fullContent.length > 0) {
+    log(logScope, 'llm.streamIncomplete', { chars: fullContent.length });
+  }
+  return { content: fullContent, complete: sawDone };
 }
 
 /**

--- a/src/main/llm/types.ts
+++ b/src/main/llm/types.ts
@@ -21,6 +21,21 @@ export interface StreamChatOptions {
   logScope?: string;
 }
 
+/**
+ * Structured result from a streaming completion. `content` is the full
+ * concatenated body of the assistant reply. `complete` is `true` only
+ * when the server's SSE stream reached its natural `[DONE]` terminator —
+ * `false` when the connection dropped mid-stream (usually a proxy or
+ * hosting-platform timeout around 300s). Callers that care about
+ * completeness (the one-shot drafter especially) use it to surface a
+ * "draft was cut off" banner instead of silently shipping a truncated
+ * artefact.
+ */
+export interface StreamChatResult {
+  content: string;
+  complete: boolean;
+}
+
 export interface CompleteTextOptions {
   messages: LlmMessage[];
   model?: string;

--- a/src/renderer/src/components/SourcesPanel.tsx
+++ b/src/renderer/src/components/SourcesPanel.tsx
@@ -26,6 +26,16 @@ export function SourcesPanel(): JSX.Element {
     await bridge.sources.delete(slug);
   }, []);
 
+  const getOriginLabel = (s: SourceMeta): string | null => {
+    if (s.type !== 'link' || !s.sourcePath) return null;
+    try {
+      const host = new URL(s.sourcePath).hostname;
+      return host.replace(/^www\./, '');
+    } catch {
+      return null;
+    }
+  };
+
   return (
     <div className="sources-panel">
       <div className="sources-panel-header">
@@ -34,25 +44,31 @@ export function SourcesPanel(): JSX.Element {
 
       {sources.length > 0 && (
         <div className="source-list-scroll">
-          {sources.map((s) => (
-            <button
-              key={s.slug}
-              type="button"
-              className="source-name-btn"
-              onClick={() => openPreview(s)}
-            >
-              <span className="source-name-label">{s.name}</span>
-              <span
-                className="source-name-delete"
-                role="button"
-                tabIndex={0}
-                onClick={(e) => void handleDelete(e, s.slug)}
-                onKeyDown={(e) => { if (e.key === 'Enter') void handleDelete(e as unknown as React.MouseEvent, s.slug); }}
+          {sources.map((s) => {
+            const origin = getOriginLabel(s);
+            return (
+              <button
+                key={s.slug}
+                type="button"
+                className="source-name-btn"
+                onClick={() => openPreview(s)}
               >
-                &#x2715;
-              </span>
-            </button>
-          ))}
+                <span className="source-name-label">
+                  <span className="source-name-title">{s.name}</span>
+                  {origin && <span className="source-name-origin">{origin}</span>}
+                </span>
+                <span
+                  className="source-name-delete"
+                  role="button"
+                  tabIndex={0}
+                  onClick={(e) => void handleDelete(e, s.slug)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') void handleDelete(e as unknown as React.MouseEvent, s.slug); }}
+                >
+                  &#x2715;
+                </span>
+              </button>
+            );
+          })}
         </div>
       )}
 

--- a/src/renderer/src/components/Welcome.tsx
+++ b/src/renderer/src/components/Welcome.tsx
@@ -156,21 +156,6 @@ function HomeView({ onOpenProjects }: { onOpenProjects: () => void }): JSX.Eleme
         evidence honest.
       </p>
 
-      <ul className="welcome-home-pillars" aria-label="What Myst does">
-        <li>
-          <strong>Anchored</strong>
-          <span>Inline citations hover to the exact source passage they quote.</span>
-        </li>
-        <li>
-          <strong>Conversational</strong>
-          <span>Chat with the Chair between rounds to shape your vision.</span>
-        </li>
-        <li>
-          <strong>End-to-end</strong>
-          <span>Vision → evidence → draft, all in one workspace.</span>
-        </li>
-      </ul>
-
       <div className="welcome-home-actions">
         <button
           type="button"

--- a/src/renderer/src/components/Welcome.tsx
+++ b/src/renderer/src/components/Welcome.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { WorkspaceProject } from '@shared/types';
+import type { UpdateStatus, WorkspaceProject } from '@shared/types';
 import { useApp } from '../store/app';
+import { useAuth } from '../store/auth';
+import { bridge } from '../api/bridge';
 import logoUrl from '../assets/logo.svg';
 
 /**
@@ -11,9 +13,16 @@ import logoUrl from '../assets/logo.svg';
  * Settings lives in a fixed corner so it never crowds the card layout.
  * The native file-dialog entry points stay as escape hatches.
  */
+type WelcomeView = 'home' | 'projects';
+
 export function Welcome(): JSX.Element {
   const { settings, openSettings } = useApp();
   const hasWorkspace = Boolean(settings?.workspaceRoot);
+  // Default signed-in landing is the Home screen. From there the user
+  // chooses whether to enter the project gallery. Workspace-not-set is
+  // still a separate branch — can't show Home without a workspace to
+  // own the projects.
+  const [view, setView] = useState<WelcomeView>('home');
 
   return (
     <div className="welcome welcome-v2">
@@ -26,7 +35,13 @@ export function Welcome(): JSX.Element {
         Settings
       </button>
       <div className="welcome-stage">
-        {hasWorkspace ? <ProjectGallery /> : <WorkspaceSetup />}
+        {!hasWorkspace ? (
+          <WorkspaceSetup />
+        ) : view === 'home' ? (
+          <HomeView onOpenProjects={() => setView('projects')} />
+        ) : (
+          <ProjectGallery onBackToHome={() => setView('home')} />
+        )}
       </div>
     </div>
   );
@@ -41,6 +56,164 @@ function SpinningLogo(props: { size: number }): JSX.Element {
       alt=""
       aria-hidden="true"
     />
+  );
+}
+
+/**
+ * Post-login landing screen. Shows app identity + version + the three
+ * actions a freshly-logged-in user reaches for: enter their project
+ * gallery, check for an update, sign out. Settings is already on the
+ * Welcome shell (corner button), so it isn't repeated here.
+ */
+function HomeView({ onOpenProjects }: { onOpenProjects: () => void }): JSX.Element {
+  const { signOut } = useAuth();
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    void bridge.updater.getStatus().then((s) => {
+      if (mounted) setStatus(s);
+    });
+    const off = bridge.updater.onChanged(() => {
+      void bridge.updater.getStatus().then((s) => {
+        if (mounted) setStatus(s);
+      });
+    });
+    return () => {
+      mounted = false;
+      off();
+    };
+  }, []);
+
+  const check = async (): Promise<void> => {
+    setChecking(true);
+    try {
+      const next = await bridge.updater.check();
+      setStatus(next);
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const install = async (): Promise<void> => {
+    try {
+      await bridge.updater.downloadAndInstall();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSignOut = async (): Promise<void> => {
+    setSigningOut(true);
+    try {
+      await signOut();
+    } finally {
+      setSigningOut(false);
+    }
+  };
+
+  const currentVersion = status?.currentVersion ?? '—';
+  const updateState = status?.state ?? 'idle';
+
+  // Update status line phrased for the home screen (Settings has its own
+  // fuller copy). We only surface the useful states here: checking,
+  // available, downloading, downloaded-ready, not-available, error.
+  let updateLine: string | null = null;
+  if (updateState === 'checking' || checking) {
+    updateLine = 'Checking…';
+  } else if (updateState === 'available') {
+    updateLine = status?.availableVersion
+      ? `Update available: v${status.availableVersion}`
+      : 'Update available';
+  } else if (updateState === 'downloading') {
+    updateLine = status?.progressPercent != null
+      ? `Downloading… ${status.progressPercent}%`
+      : 'Downloading…';
+  } else if (updateState === 'downloaded') {
+    updateLine = status?.availableVersion
+      ? `v${status.availableVersion} ready — restart to install`
+      : 'Update ready';
+  } else if (updateState === 'not-available') {
+    updateLine = 'You\'re on the latest version.';
+  } else if (updateState === 'error') {
+    updateLine = status?.error ?? 'Update check failed.';
+  }
+
+  const showRestart = updateState === 'downloaded';
+  const checkDisabled =
+    checking || updateState === 'checking' || updateState === 'downloading' || updateState === 'disabled';
+
+  return (
+    <div className="welcome-hero welcome-home">
+      <SpinningLogo size={120} />
+      <h1 className="welcome-title">Open Myst</h1>
+      <p className="welcome-tagline">Your grounded research collaborator.</p>
+      <p className="welcome-lede">
+        Every claim traces back to a verbatim source. A panel of agents
+        helps you think it through. You steer the vision; Myst keeps the
+        evidence honest.
+      </p>
+
+      <ul className="welcome-home-pillars" aria-label="What Myst does">
+        <li>
+          <strong>Anchored</strong>
+          <span>Inline citations hover to the exact source passage they quote.</span>
+        </li>
+        <li>
+          <strong>Conversational</strong>
+          <span>Chat with the Chair between rounds to shape your vision.</span>
+        </li>
+        <li>
+          <strong>End-to-end</strong>
+          <span>Vision → evidence → draft, all in one workspace.</span>
+        </li>
+      </ul>
+
+      <div className="welcome-home-actions">
+        <button
+          type="button"
+          className="welcome-bubble welcome-bubble-primary welcome-bubble-lg"
+          onClick={onOpenProjects}
+        >
+          Go to my projects →
+        </button>
+
+        <div className="welcome-home-secondary">
+          <button
+            type="button"
+            className="welcome-bubble welcome-bubble-ghost"
+            onClick={() => void check()}
+            disabled={checkDisabled}
+          >
+            Check for updates
+          </button>
+          {showRestart && (
+            <button
+              type="button"
+              className="welcome-bubble"
+              onClick={() => void install()}
+            >
+              Restart &amp; install
+            </button>
+          )}
+          <button
+            type="button"
+            className="welcome-bubble welcome-bubble-ghost"
+            onClick={() => void handleSignOut()}
+            disabled={signingOut}
+          >
+            {signingOut ? 'Signing out…' : 'Sign out'}
+          </button>
+        </div>
+
+        <p className="welcome-home-footnote muted">
+          v{currentVersion}
+          {updateLine ? <> · {updateLine}</> : null}
+        </p>
+      </div>
+    </div>
   );
 }
 
@@ -98,7 +271,7 @@ function WorkspaceSetup(): JSX.Element {
   );
 }
 
-function ProjectGallery(): JSX.Element {
+function ProjectGallery({ onBackToHome }: { onBackToHome: () => void }): JSX.Element {
   const {
     settings,
     workspaceProjects,
@@ -172,19 +345,28 @@ function ProjectGallery(): JSX.Element {
           <button
             type="button"
             className="welcome-bubble welcome-bubble-ghost"
-            onClick={() => void openExistingProject()}
-            disabled={loading}
+            onClick={onBackToHome}
           >
-            Open from disk…
+            ← Home
           </button>
-          <button
-            type="button"
-            className="welcome-bubble welcome-bubble-ghost"
-            onClick={() => void pickWorkspaceRoot()}
-            disabled={loading}
-          >
-            Change workspace folder
-          </button>
+          <div className="welcome-gallery-footer-right">
+            <button
+              type="button"
+              className="welcome-bubble welcome-bubble-ghost"
+              onClick={() => void openExistingProject()}
+              disabled={loading}
+            >
+              Open from disk…
+            </button>
+            <button
+              type="button"
+              className="welcome-bubble welcome-bubble-ghost"
+              onClick={() => void pickWorkspaceRoot()}
+              disabled={loading}
+            >
+              Change workspace folder
+            </button>
+          </div>
         </footer>
 
         {error && (

--- a/src/renderer/src/components/deepPlan/ConversationColumn.tsx
+++ b/src/renderer/src/components/deepPlan/ConversationColumn.tsx
@@ -76,12 +76,30 @@ export function ConversationColumn({ session }: Props): JSX.Element {
     return () => el.removeEventListener('scroll', onScroll);
   }, []);
 
+  // Count signals that should trigger a scroll-if-pinned: new messages,
+  // pending-question card appearing, round boundaries, AND individual
+  // panel-role completions / chair state changes during an in-flight
+  // round (so live panel-thoughts that extend past the viewport bring
+  // a pinned user down to them). `pinnedRef` stays false as soon as
+  // the user scrolls up, so none of these re-pull them against their
+  // will — they stay where they chose until they scroll back to bottom.
+  const panelDoneCount = useMemo(
+    () => Object.values(panelProgress.byRole).filter((r) => r.state === 'done').length,
+    [panelProgress.byRole],
+  );
+  const chairStage = panelProgress.chair;
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     if (!pinnedRef.current) return;
     el.scrollTo({ top: el.scrollHeight });
-  }, [session.messages.length, pendingQuestions.length, roundRunning]);
+  }, [
+    session.messages.length,
+    pendingQuestions.length,
+    roundRunning,
+    panelDoneCount,
+    chairStage,
+  ]);
 
   const isDone = session.phase === 'done';
 
@@ -339,21 +357,13 @@ function PanelThoughtBody({
   return (
     <div className="dp-panel-role-thought">
       {visionNotes && <p className="dp-panel-role-thought-note">{visionNotes}</p>}
-      {researchRequests.length > 0 && (
-        <ul className="dp-panel-role-thought-searches">
-          {researchRequests.map((req, i) => (
-            <li key={i} className="dp-panel-role-thought-search">
-              <p className="dp-panel-role-thought-search-line">
-                <span className="dp-panel-role-thought-search-label">Search:</span>{' '}
-                {req.query}
-              </p>
-              {req.rationale && (
-                <p className="dp-panel-role-thought-search-why">{req.rationale}</p>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+      {researchRequests.map((req, i) => (
+        <p key={i} className="dp-panel-role-thought-search-line">
+          <span className="dp-panel-role-thought-search-label">Search:</span>{' '}
+          <span className="dp-panel-role-thought-search-query">{req.query}</span>
+          {req.rationale && <> - {req.rationale}</>}
+        </p>
+      ))}
     </div>
   );
 }

--- a/src/renderer/src/components/deepPlan/ConversationColumn.tsx
+++ b/src/renderer/src/components/deepPlan/ConversationColumn.tsx
@@ -310,23 +310,51 @@ function PanelDiscussionItem({ output }: { output: PanelOutput }): JSX.Element {
   return (
     <li className={`dp-panel-discussion-item${silent ? ' dp-panel-discussion-item-silent' : ''}`}>
       <div className="dp-panel-discussion-role">{output.role}</div>
-      {output.visionNotes.trim() && (
-        <p className="dp-panel-discussion-note">{output.visionNotes.trim()}</p>
+      {silent ? (
+        <div className="dp-panel-role-tagline dp-panel-role-silent">No notes.</div>
+      ) : (
+        <PanelThoughtBody
+          visionNotes={output.visionNotes.trim()}
+          researchRequests={output.needsResearch}
+        />
       )}
-      {output.needsResearch.length > 0 && (
-        <ul className="dp-panel-discussion-research">
-          {output.needsResearch.map((req, i) => (
-            <li key={i}>
-              <span className="dp-panel-discussion-research-query">“{req.query}”</span>
+    </li>
+  );
+}
+
+/**
+ * Shared render for a panelist's thought: the vision note + any research
+ * requests with their rationale. Used both by the live PanelProgressPanel
+ * (while the round is running) and the post-round PanelDiscussion
+ * accordion (on completed chair-turn messages), so both paths share the
+ * same type scale + bullet style.
+ */
+function PanelThoughtBody({
+  visionNotes,
+  researchRequests,
+}: {
+  visionNotes: string;
+  researchRequests: PanelOutput['needsResearch'];
+}): JSX.Element {
+  return (
+    <div className="dp-panel-role-thought">
+      {visionNotes && <p className="dp-panel-role-thought-note">{visionNotes}</p>}
+      {researchRequests.length > 0 && (
+        <ul className="dp-panel-role-thought-searches">
+          {researchRequests.map((req, i) => (
+            <li key={i} className="dp-panel-role-thought-search">
+              <p className="dp-panel-role-thought-search-line">
+                <span className="dp-panel-role-thought-search-label">Search:</span>{' '}
+                {req.query}
+              </p>
               {req.rationale && (
-                <span className="dp-panel-discussion-research-why"> — {req.rationale}</span>
+                <p className="dp-panel-role-thought-search-why">{req.rationale}</p>
               )}
             </li>
           ))}
         </ul>
       )}
-      {silent && <p className="dp-panel-discussion-note dp-muted">(no notes this round)</p>}
-    </li>
+    </div>
   );
 }
 
@@ -467,7 +495,15 @@ function PanelProgressPanel({ progress }: PanelProgressPanelProps): JSX.Element 
   const status: string = (() => {
     if (chair === 'running') return 'Chair is synthesising the panel’s findings…';
     if (chair === 'done') return 'Chair is finalising your questions…';
-    if (doneCount === roles.length && roles.length > 0) return 'Panel is done deliberating.';
+    const panelDone = doneCount === roles.length && roles.length > 0;
+    // Once the panel is done and they've asked for research, the
+    // orchestrator is fetching pages before the Chair fires. Surface
+    // that explicitly so the user isn't staring at "Panel is done
+    // deliberating" while web fetches are in flight.
+    if (panelDone && researchDispatched > 0) {
+      return `Searching the web — ${researchDispatched} ${researchDispatched === 1 ? 'query' : 'queries'} in flight…`;
+    }
+    if (panelDone) return 'Panel is done deliberating.';
     if (runningCount > 0) return `${runningCount} panelist${runningCount === 1 ? '' : 's'} still thinking…`;
     return 'Panel is assembling…';
   })();
@@ -533,27 +569,12 @@ function PanelProgressPanel({ progress }: PanelProgressPanelProps): JSX.Element 
                  *  users read the panel's thinking while the Chair is
                  *  still synthesising. */}
                 {state === 'done' && (visionNotes || researchRequests.length > 0) ? (
-                  <div className="dp-panel-role-thought">
-                    {visionNotes && (
-                      <p className="dp-panel-role-thought-note">{visionNotes}</p>
-                    )}
-                    {researchRequests.length > 0 && (
-                      <ul className="dp-panel-role-thought-research">
-                        {researchRequests.map((req, i) => (
-                          <li key={i}>
-                            <span className="dp-panel-role-thought-query">“{req.query}”</span>
-                            {req.rationale && (
-                              <span className="dp-panel-role-thought-why"> — {req.rationale}</span>
-                            )}
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
+                  <PanelThoughtBody
+                    visionNotes={visionNotes}
+                    researchRequests={researchRequests}
+                  />
                 ) : state === 'done' ? (
-                  <div className="dp-panel-role-tagline dp-panel-role-silent">
-                    No new notes from this lens.
-                  </div>
+                  <div className="dp-panel-role-tagline dp-panel-role-silent">No notes.</div>
                 ) : (
                   <div className="dp-panel-role-tagline">
                     {state === 'failed' && errorMsg ? errorMsg : meta.tagline}

--- a/src/renderer/src/components/deepPlan/ConversationColumn.tsx
+++ b/src/renderer/src/components/deepPlan/ConversationColumn.tsx
@@ -9,14 +9,9 @@ import type {
   PanelRole,
 } from '@shared/types';
 import { useDeepPlan, type PanelProgressState } from '../../store/deepPlan';
-import { useResearchEvents } from '../../store/researchEvents';
 import { renderMarkdown } from '../../utils/markdown';
 import { QuestionCard } from './QuestionCard';
 import { CitationHoverScope } from './CitationHoverScope';
-import {
-  latestQueryText,
-  researchRunningFromEvents,
-} from '../../hooks/useResearchFlash';
 
 function Markdown({ text }: { text: string }): JSX.Element {
   const html = useMemo(() => renderMarkdown(text), [text]);
@@ -126,7 +121,6 @@ export function ConversationColumn({ session }: Props): JSX.Element {
           />
         ))}
         {roundRunning && <PanelProgressPanel progress={panelProgress} />}
-        {roundRunning && <SearchingBanner />}
         {!roundRunning && pendingQuestions.length > 0 && (
           <QuestionCard questions={pendingQuestions} />
         )}
@@ -439,37 +433,6 @@ function AnswersRecap({ answers, questions }: AnswersRecapProps): JSX.Element | 
 
 /* ---------------------------- Searching banner ---------------------------- */
 
-/**
- * Shown below the panel card while the research engine is mid-run. The
- * floating pill on the graph already calls this out visually — this chat-
- * side banner exists so users who are scrolled up in the transcript (or
- * focused on the conversation column) also see that we're actively
- * searching the web and shouldn't close the window.
- */
-function SearchingBanner(): JSX.Element | null {
-  const events = useResearchEvents((s) => s.events);
-  const searching = useMemo(() => researchRunningFromEvents(events), [events]);
-  const currentQuery = useMemo(() => latestQueryText(events), [events]);
-  if (!searching) return null;
-  return (
-    <div className="dp-searching" role="status" aria-live="polite">
-      <span className="dp-searching-icon generating-dots" aria-hidden>
-        <span className="dot" />
-        <span className="dot" />
-        <span className="dot" />
-      </span>
-      <div className="dp-searching-body">
-        <div className="dp-searching-title">Searching the web — sit tight</div>
-        <div className="dp-searching-sub">
-          {currentQuery
-            ? `Looking up “${currentQuery}”`
-            : 'Running the queries the panel asked for…'}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 /* ---------------------------- Panel progress ---------------------------- */
 
 /**
@@ -541,6 +504,10 @@ function PanelProgressPanel({ progress }: PanelProgressPanelProps): JSX.Element 
             entry?.state === 'done'
               ? entry.searchQueries
               : undefined;
+          const visionNotes =
+            entry?.state === 'done' ? entry.visionNotes.trim() : '';
+          const researchRequests =
+            entry?.state === 'done' ? entry.needsResearch : [];
           const errorMsg = entry?.state === 'failed' ? entry.error : undefined;
 
           return (
@@ -560,9 +527,38 @@ function PanelProgressPanel({ progress }: PanelProgressPanelProps): JSX.Element 
                     searchQueries={searchQueries}
                   />
                 </div>
-                <div className="dp-panel-role-tagline">
-                  {state === 'failed' && errorMsg ? errorMsg : meta.tagline}
-                </div>
+                {/* Live panel thought. While running we show the persona's
+                 *  tagline; when the role finishes, its actual vision note
+                 *  + research requests replace the tagline immediately so
+                 *  users read the panel's thinking while the Chair is
+                 *  still synthesising. */}
+                {state === 'done' && (visionNotes || researchRequests.length > 0) ? (
+                  <div className="dp-panel-role-thought">
+                    {visionNotes && (
+                      <p className="dp-panel-role-thought-note">{visionNotes}</p>
+                    )}
+                    {researchRequests.length > 0 && (
+                      <ul className="dp-panel-role-thought-research">
+                        {researchRequests.map((req, i) => (
+                          <li key={i}>
+                            <span className="dp-panel-role-thought-query">“{req.query}”</span>
+                            {req.rationale && (
+                              <span className="dp-panel-role-thought-why"> — {req.rationale}</span>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                ) : state === 'done' ? (
+                  <div className="dp-panel-role-tagline dp-panel-role-silent">
+                    No new notes from this lens.
+                  </div>
+                ) : (
+                  <div className="dp-panel-role-tagline">
+                    {state === 'failed' && errorMsg ? errorMsg : meta.tagline}
+                  </div>
+                )}
               </div>
             </li>
           );

--- a/src/renderer/src/components/deepPlan/ConversationColumn.tsx
+++ b/src/renderer/src/components/deepPlan/ConversationColumn.tsx
@@ -5,6 +5,7 @@ import type {
   ChairQuestion,
   DeepPlanMessage,
   DeepPlanSession,
+  PanelOutput,
   PanelRole,
 } from '@shared/types';
 import { useDeepPlan, type PanelProgressState } from '../../store/deepPlan';
@@ -269,12 +270,69 @@ function MessageBubble({
   }
 
   const klass = message.role === 'user' ? 'dp-msg dp-msg-user' : 'dp-msg dp-msg-assistant';
+  const panelOutputs = message.kind === 'chair-turn' ? message.panel : undefined;
   return (
     <div className={klass}>
       <div className="dp-msg-body">
         <Markdown text={message.content} />
+        {panelOutputs && panelOutputs.length > 0 && (
+          <PanelDiscussion outputs={panelOutputs} />
+        )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Collapsible accordion showing each panel role's contribution to the
+ * round: their vision note, their research requests. Hidden by default
+ * so the Chair summary stays the primary read; users who want to see
+ * the mechanics expand it.
+ */
+function PanelDiscussion({ outputs }: { outputs: PanelOutput[] }): JSX.Element {
+  const contributingRoles = outputs.filter(
+    (p) => p.visionNotes.trim().length > 0 || p.needsResearch.length > 0,
+  );
+  return (
+    <details className="dp-panel-discussion">
+      <summary className="dp-panel-discussion-summary">
+        Panel discussion ·{' '}
+        {contributingRoles.length > 0
+          ? `${contributingRoles.length} of ${outputs.length} contributed`
+          : `all ${outputs.length} silent`}
+      </summary>
+      <ul className="dp-panel-discussion-list">
+        {outputs.map((p) => (
+          <PanelDiscussionItem key={p.role} output={p} />
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+function PanelDiscussionItem({ output }: { output: PanelOutput }): JSX.Element {
+  const silent =
+    !output.visionNotes.trim() && output.needsResearch.length === 0;
+  return (
+    <li className={`dp-panel-discussion-item${silent ? ' dp-panel-discussion-item-silent' : ''}`}>
+      <div className="dp-panel-discussion-role">{output.role}</div>
+      {output.visionNotes.trim() && (
+        <p className="dp-panel-discussion-note">{output.visionNotes.trim()}</p>
+      )}
+      {output.needsResearch.length > 0 && (
+        <ul className="dp-panel-discussion-research">
+          {output.needsResearch.map((req, i) => (
+            <li key={i}>
+              <span className="dp-panel-discussion-research-query">“{req.query}”</span>
+              {req.rationale && (
+                <span className="dp-panel-discussion-research-why"> — {req.rationale}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {silent && <p className="dp-panel-discussion-note dp-muted">(no notes this round)</p>}
+    </li>
   );
 }
 

--- a/src/renderer/src/store/deepPlan.ts
+++ b/src/renderer/src/store/deepPlan.ts
@@ -4,6 +4,7 @@ import type {
   DeepPlanSession,
   DeepPlanStatus,
   PanelProgressEvent,
+  PanelResearchRequest,
   PanelRole,
 } from '@shared/types';
 import { bridge } from '../api/bridge';
@@ -21,7 +22,14 @@ import { bridge } from '../api/bridge';
 export type PanelRoleStatus =
   | { state: 'pending' }
   | { state: 'running' }
-  | { state: 'done'; findings: number; searchQueries: number }
+  | {
+      state: 'done';
+      findings: number;
+      searchQueries: number;
+      /** Streamed through from the main process when the role finishes. */
+      visionNotes: string;
+      needsResearch: PanelResearchRequest[];
+    }
   | { state: 'failed'; error: string };
 
 export interface PanelProgressState {
@@ -238,6 +246,8 @@ export const useDeepPlan = create<DeepPlanState>((set, get) => ({
             state: 'done',
             findings: event.findings,
             searchQueries: event.searchQueries,
+            visionNotes: event.visionNotes,
+            needsResearch: event.needsResearch,
           };
           return { panelProgress: progress };
         case 'role-failed':

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -463,13 +463,17 @@ h3 {
   padding: 22px 24px;
   border-bottom: 1px solid var(--border);
 }
-/* Home landing — post-login default. Vertical stack with copy that
- * fills the space: title, tagline, lede paragraph, three-pillar grid,
- * primary CTA, secondary action row, version/update footnote. */
+/* Home landing — post-login default. Vertical stack with title,
+ * tagline, lede paragraph, primary CTA, secondary action row,
+ * version/update footnote. Narrower than the stage on purpose —
+ * `align-self: center` keeps it horizontally centred inside the
+ * 720px stage rather than pinning to the left edge. */
 .welcome-home {
   padding-top: 48px;
   padding-bottom: 44px;
   max-width: 640px;
+  align-self: center;
+  width: 100%;
 }
 .welcome-tagline {
   font-size: 17px;
@@ -484,36 +488,6 @@ h3 {
   line-height: 1.55;
   margin: 14px 0 0;
   max-width: 480px;
-}
-.welcome-home-pillars {
-  list-style: none;
-  padding: 0;
-  margin: 28px 0 8px;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-  width: 100%;
-}
-.welcome-home-pillars li {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  padding: 14px 14px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--bg-panel) 60%, transparent);
-  text-align: left;
-}
-.welcome-home-pillars strong {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--fg);
-}
-.welcome-home-pillars span {
-  font-size: 12px;
-  color: var(--fg-muted);
-  line-height: 1.45;
 }
 .welcome-home-actions {
   display: flex;
@@ -536,12 +510,6 @@ h3 {
 .welcome-home-status {
   margin: 4px 0 0;
   font-size: 12px;
-}
-
-@media (max-width: 560px) {
-  .welcome-home-pillars {
-    grid-template-columns: 1fr;
-  }
 }
 .welcome-gallery-hero-text {
   flex: 1;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -907,9 +907,23 @@ img.login-logo {
 }
 .source-name-label {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.source-name-title {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.source-name-origin {
+  font-size: 10px;
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
 }
 .source-name-delete {
   color: var(--fg-muted);

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4645,6 +4645,44 @@ img.login-logo {
   color: var(--muted);
   line-height: 1.45;
 }
+.dp-panel-role-silent {
+  font-style: italic;
+  opacity: 0.7;
+}
+
+/* Live panel thought — rendered inline under a role's header the
+ * moment the role finishes. Replaces the persona tagline so users see
+ * the actual thought the panelist landed on, not a generic descriptor.
+ * Intentionally readable body copy, not a status chip. */
+.dp-panel-role-thought {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+}
+.dp-panel-role-thought-note {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg);
+}
+.dp-panel-role-thought-research {
+  list-style: disc;
+  margin: 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dp-panel-role-thought-query {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--fg);
+}
+.dp-panel-role-thought-why {
+  font-style: italic;
+}
 .dp-panel-role-note {
   font-size: 11px;
   color: var(--muted);

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4650,38 +4650,54 @@ img.login-logo {
   opacity: 0.7;
 }
 
-/* Live panel thought — rendered inline under a role's header the
- * moment the role finishes. Replaces the persona tagline so users see
- * the actual thought the panelist landed on, not a generic descriptor.
- * Intentionally readable body copy, not a status chip. */
+/* Live panel thought — rendered inline under a role's header the moment
+ * it finishes. Plain body copy, minimal type variation — the role name
+ * + status chip above already carry the visual weight. The note is the
+ * content, the search line is supporting context. */
 .dp-panel-role-thought {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 3px;
   margin-top: 2px;
 }
 .dp-panel-role-thought-note {
   margin: 0;
-  font-size: 13px;
+  font-size: 12.5px;
   line-height: 1.5;
   color: var(--fg);
 }
-.dp-panel-role-thought-research {
+.dp-panel-role-thought-searches {
   list-style: disc;
-  margin: 0;
   padding-left: 18px;
-  font-size: 12px;
-  color: var(--muted);
+  margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
-.dp-panel-role-thought-query {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  color: var(--fg);
+.dp-panel-role-thought-search {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
 }
-.dp-panel-role-thought-why {
-  font-style: italic;
+.dp-panel-role-thought-search::marker {
+  color: var(--muted);
+}
+.dp-panel-role-thought-search-line {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--muted);
+}
+.dp-panel-role-thought-search-label {
+  color: var(--muted);
+  opacity: 0.7;
+}
+.dp-panel-role-thought-search-why {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--muted);
+  opacity: 0.75;
 }
 .dp-panel-role-note {
   font-size: 11px;
@@ -5449,29 +5465,8 @@ img.login-logo {
 .dp-panel-discussion-item-silent .dp-panel-discussion-role {
   color: var(--muted);
 }
-.dp-panel-discussion-note {
-  font-size: 13px;
-  line-height: 1.45;
-  margin: 0;
-  color: var(--fg);
-}
-.dp-panel-discussion-research {
-  list-style: disc;
-  margin: 0;
-  padding-left: 18px;
-  font-size: 12.5px;
-  color: var(--muted);
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-.dp-panel-discussion-research-query {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  color: var(--fg);
-}
-.dp-panel-discussion-research-why {
-  font-style: italic;
-}
+/* Thought body + search list styling lives under
+ * `.dp-panel-role-thought*` and is shared with the live panel view. */
 
 /* Free-chat bubbles — same markdown treatment as normal messages but
  * visually lighter so the user can distinguish "just talking to the

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -463,6 +463,86 @@ h3 {
   padding: 22px 24px;
   border-bottom: 1px solid var(--border);
 }
+/* Home landing — post-login default. Vertical stack with copy that
+ * fills the space: title, tagline, lede paragraph, three-pillar grid,
+ * primary CTA, secondary action row, version/update footnote. */
+.welcome-home {
+  padding-top: 48px;
+  padding-bottom: 44px;
+  max-width: 640px;
+}
+.welcome-tagline {
+  font-size: 17px;
+  font-weight: 500;
+  color: var(--fg);
+  margin: 6px 0 0;
+  letter-spacing: -0.01em;
+}
+.welcome-lede {
+  font-size: 13.5px;
+  color: var(--fg-muted);
+  line-height: 1.55;
+  margin: 14px 0 0;
+  max-width: 480px;
+}
+.welcome-home-pillars {
+  list-style: none;
+  padding: 0;
+  margin: 28px 0 8px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  width: 100%;
+}
+.welcome-home-pillars li {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 14px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-panel) 60%, transparent);
+  text-align: left;
+}
+.welcome-home-pillars strong {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--fg);
+}
+.welcome-home-pillars span {
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1.45;
+}
+.welcome-home-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 22px;
+  width: 100%;
+}
+.welcome-home-secondary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+.welcome-home-footnote {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+}
+.welcome-home-status {
+  margin: 4px 0 0;
+  font-size: 12px;
+}
+
+@media (max-width: 560px) {
+  .welcome-home-pillars {
+    grid-template-columns: 1fr;
+  }
+}
 .welcome-gallery-hero-text {
   flex: 1;
   min-width: 0;
@@ -584,9 +664,13 @@ h3 {
 .welcome-gallery-footer {
   display: flex;
   gap: 8px;
-  justify-content: flex-end;
+  justify-content: space-between;
   padding: 10px 14px;
   border-top: 1px solid var(--border);
+}
+.welcome-gallery-footer-right {
+  display: flex;
+  gap: 8px;
 }
 
 /* ---- Error ---- */

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4641,22 +4641,10 @@ img.login-logo {
   line-height: 1.5;
   color: var(--fg);
 }
-.dp-panel-role-thought-searches {
-  list-style: disc;
-  padding-left: 18px;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.dp-panel-role-thought-search {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-.dp-panel-role-thought-search::marker {
-  color: var(--muted);
-}
+/* Search lines are flat paragraphs, not a bullet list — they sit with
+ * the same left margin as the vision note above so everything reads as
+ * one continuous thought block. Query + rationale on a single line
+ * separated by " - " so the whole thing flows inline. */
 .dp-panel-role-thought-search-line {
   margin: 0;
   font-size: 11.5px;
@@ -4667,12 +4655,12 @@ img.login-logo {
   color: var(--muted);
   opacity: 0.7;
 }
-.dp-panel-role-thought-search-why {
-  margin: 0;
-  font-size: 11px;
-  line-height: 1.4;
-  color: var(--muted);
-  opacity: 0.75;
+.dp-panel-role-thought-search-query {
+  font-weight: 600;
+  /* Warm purple-brown so the query pops against the muted rationale
+   * without clashing with the accent rose used elsewhere. Picks up the
+   * theme's plum family but dialled toward the brown end. */
+  color: #a97f89;
 }
 .dp-panel-role-note {
   font-size: 11px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1972,27 +1972,34 @@ img.login-logo {
   color: var(--accent);
   font-style: italic;
 }
-/* Thinking indicator — spinning Open Myst logo in place of three dots.
- * Used wherever a stream hasn't produced visible text yet. Callers still
- * pass three <.dot> spans inside; we hide them and render the logo via
- * a background-image on the container so no TSX changes are needed. */
+/* Thinking indicator — three pulsing dots. Used inline wherever a
+ * stream hasn't produced visible text yet. Matches the Deep Plan
+ * panel-status indicator so the app's loading affordances are
+ * consistent; previously this class rendered a spinning logo which
+ * felt decorative next to the panel's tighter 3-dot animation. */
 .generating-dots {
-  display: inline-block;
-  width: 18px;
-  height: 18px;
-  vertical-align: text-bottom;
-  background-image: url('./assets/logo.svg');
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  animation: app-logo-spin 2.2s linear infinite;
-  will-change: transform;
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+  vertical-align: middle;
 }
 .generating-dots .dot {
-  display: none;
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent, currentColor);
+  opacity: 0.55;
+  animation: generating-dots-pulse 1.2s ease-in-out infinite;
+}
+.generating-dots .dot:nth-child(2) { animation-delay: 160ms; }
+.generating-dots .dot:nth-child(3) { animation-delay: 320ms; }
+@keyframes generating-dots-pulse {
+  0%, 80%, 100% { opacity: 0.25; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
 }
 @media (prefers-reduced-motion: reduce) {
-  .generating-dots { animation: none; }
+  .generating-dots .dot { animation: none; opacity: 0.55; }
 }
 .chat-error {
   padding: 8px 16px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -5349,6 +5349,92 @@ img.login-logo {
   color: #d89a2b;
 }
 
+/* Panel discussion accordion — collapsed summary line under each Chair
+ * turn. Hidden detail; click to expand and see every role's note +
+ * research request. Keeps the Chair summary primary while making the
+ * panel's thinking legible to users who want to see it. */
+.dp-panel-discussion {
+  margin-top: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-panel) 60%, transparent);
+}
+.dp-panel-discussion-summary {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.dp-panel-discussion-summary::-webkit-details-marker {
+  display: none;
+}
+.dp-panel-discussion-summary::before {
+  content: '▸ ';
+  display: inline-block;
+  margin-right: 4px;
+  transition: transform 0.15s ease;
+}
+.dp-panel-discussion[open] > .dp-panel-discussion-summary::before {
+  content: '▾ ';
+}
+.dp-panel-discussion-summary:hover {
+  color: var(--fg);
+}
+.dp-panel-discussion-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.dp-panel-discussion-item {
+  padding-top: 10px;
+  border-top: 1px dashed var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.dp-panel-discussion-item:first-child {
+  border-top: none;
+  padding-top: 4px;
+}
+.dp-panel-discussion-role {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--accent);
+}
+.dp-panel-discussion-item-silent .dp-panel-discussion-role {
+  color: var(--muted);
+}
+.dp-panel-discussion-note {
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 0;
+  color: var(--fg);
+}
+.dp-panel-discussion-research {
+  list-style: disc;
+  margin: 0;
+  padding-left: 18px;
+  font-size: 12.5px;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.dp-panel-discussion-research-query {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--fg);
+}
+.dp-panel-discussion-research-why {
+  font-style: italic;
+}
+
 /* Free-chat bubbles — same markdown treatment as normal messages but
  * visually lighter so the user can distinguish "just talking to the
  * Chair" from "weighty panel-round summary". */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -445,6 +445,13 @@ export interface DeepPlanMessage {
   chair?: ChairOutput;
   /** Populated when `kind === 'user-answers'`. */
   answers?: ChairAnswerMap;
+  /**
+   * Per-role panel outputs from the round this chair-turn synthesised.
+   * The UI surfaces these as a collapsible "Panel discussion" accordion
+   * under the Chair's summary so the session isn't a black box — users
+   * can see what each role actually contributed.
+   */
+  panel?: PanelOutput[];
 }
 
 export interface DeepPlanSession {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -382,7 +382,16 @@ export interface AnchorLogEntry {
 export type PanelProgressEvent =
   | { kind: 'round-start'; phase: DeepPlanPhase; roles: PanelRole[] }
   | { kind: 'role-start'; role: PanelRole }
-  | { kind: 'role-done'; role: PanelRole; findings: number; searchQueries: number }
+  | {
+      kind: 'role-done';
+      role: PanelRole;
+      findings: number;
+      searchQueries: number;
+      /** The vision-note text the role emitted this round (empty string when silent). Streamed to the UI so users see the thought live. */
+      visionNotes: string;
+      /** Any research queries the role asked for this round — same order the parser produced. */
+      needsResearch: PanelResearchRequest[];
+    }
   | { kind: 'role-failed'; role: PanelRole; error: string }
   | { kind: 'research-dispatched'; queries: number }
   | { kind: 'chair-start' }


### PR DESCRIPTION
# Summary
## Resilience

- Auto-continue on dropped streams — when the upstream proxy cuts the drafter at ~300s, we silently replay with the partial content as the prior assistant turn and resume. Chunks keep broadcasting to the same channel, so the UI sees one continuous stream. Up to 3 continuations (~20 min of drafting headroom).
StreamChatResult return type — streamChat now returns { content, complete } so any caller can detect incomplete streams. All existing callers (chat turns, lookup resolution) updated.
- Panel concurrency cap (5) — parallel panel + research fetches no longer cascade into the same backend rate-limit window.
- 429 retry helper — respects Retry-After header, falls back to parsing "Try again in Xs" out of the body, caps waits at 30s.

## Deep Plan UX
- Panel discussion rendering — live panel thoughts appear incrementally after each member, plus a collapsible post-round accordion, both sharing one PanelThoughtBody component.
- Inline search display — flat Search: <query> - <reason> format; query bolded in purple-brown (#a97f89) to distinguish from definition text.
- Auto-scroll on generation — follows user down as new tokens arrive, but yields to manual scroll-up.
- Chair loading — same spinner as panel (no more full-logo lockup).
- Phase-advance bug fix — prompt hardening so the Chair emits phaseAdvance: true instead of asking "ready to advance?" as a question.
- Vision prompt rebalanced — emphasises ideas and novel insights over rigid heading scaffolds.
- References section — now includes both [[web](url)] and [[source](slug.md)] links for each citation.

## Home view
- Three-pillar grid removed, centred layout, tagline added ("your grounded research collaborator"), update-status + sign-out + projects actions surfaced for signed-in users.

## Sources
- Origin label under source titles — link-type sources now show their hostname (e.g. medium.com) in small muted text below the name.
- Credibility gate — YouTube, Amazon, and forum URLs hard-blocked from ingestion; primary-source guidance added to panel prompts.

## Settings
- Model defaults versioning — CURRENT_MODEL_DEFAULTS_VERSION bump forces existing installs to the new gemma/gemini-flash-lite defaults. Panel, Chair, Drafter, and summary models are independent slots.