### PR TITLE
feat: Panel + Chair: User-driven question/search overhaul

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmyst",
   "productName": "Open Myst",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "An open-source desktop research companion. Write, comment, and let an LLM propose inline edits against your own knowledge wiki.",
   "author": "Open Myst",

--- a/src/main/features/deepPlan/chair.ts
+++ b/src/main/features/deepPlan/chair.ts
@@ -1,5 +1,6 @@
 import { IpcChannels } from '@shared/ipc-channels';
 import type {
+  AnchorLogEntry,
   ChairAnswerMap,
   ChairOutput,
   ChairQuestion,
@@ -175,6 +176,10 @@ export async function runChair(args: {
   newlyIngestedSourceSlugs: string[];
   roundNumber: number;
   sources: SourceMeta[];
+  /** Anchors not yet shown to the Chair (filtered against `session.seenAnchorIds`). */
+  newAnchors: AnchorLogEntry[];
+  /** Total anchor count across the wiki, for the "you've seen N already" prompt line. */
+  totalAnchorCount: number;
   lastAnswers: ChairAnswerMap | null;
   /** User's free-chat notes since the last panel round — steering, not overriding. */
   chatNotes: string[];
@@ -188,6 +193,8 @@ export async function runChair(args: {
     newlyIngestedSourceSlugs: args.newlyIngestedSourceSlugs,
     roundNumber: args.roundNumber,
     sources: args.sources,
+    newAnchors: args.newAnchors,
+    totalAnchorCount: args.totalAnchorCount,
     lastAnswers: args.lastAnswers,
     chatNotes: args.chatNotes,
   });

--- a/src/main/features/deepPlan/index.ts
+++ b/src/main/features/deepPlan/index.ts
@@ -4,6 +4,7 @@ import type {
   ChairAnswerMap,
   ChairOutput,
   DeepPlanMessage,
+  DeepPlanMode,
   DeepPlanSession,
   DeepPlanStatus,
 } from '@shared/types';
@@ -135,10 +136,13 @@ function lastUserAnswers(session: DeepPlanSession): ChairAnswerMap | null {
 
 /* ------------------------------ Public API ------------------------------ */
 
-export async function startSession(task: string): Promise<DeepPlanStatus> {
+export async function startSession(
+  task: string,
+  mode: DeepPlanMode = 'argumentative-essay',
+): Promise<DeepPlanStatus> {
   if (!task.trim()) throw new Error('Task description cannot be empty.');
   await deleteSession();
-  await createSession(task);
+  await createSession(task, mode);
   notifyChanged();
   // Fire the first panel round immediately — no opener chat message, the
   // Chair's first summary is the opener.
@@ -372,10 +376,14 @@ async function runPanelAndChair(): Promise<void> {
     const sourcesForChair =
       newlyIngestedSourceSlugs.length > 0 ? await listSources() : sources;
 
-    // No more anchor-log resolve+append step — anchors live on disk in
-    // each source's index file, and the UI / drafter read them directly
-    // via `listAllAnchors`. The only thing the panel round owns now is
-    // vision notes + research dispatch.
+    // Anchor universe for the Chair: read every anchor across every
+    // source, then filter against `seenAnchorIds` so the Chair only sees
+    // what's NEW this round. Keeps context tight as the wiki grows AND
+    // forces vision updates to ground in fresh evidence rather than
+    // re-shuffling earlier abstractions.
+    const allAnchors = await listAllAnchors();
+    const seenSet = new Set(session.seenAnchorIds);
+    const newAnchors = allAnchors.filter((a) => !seenSet.has(a.id));
 
     const chairOutput = await runChair({
       session,
@@ -383,6 +391,8 @@ async function runPanelAndChair(): Promise<void> {
       newlyIngestedSourceSlugs,
       roundNumber,
       sources: sourcesForChair,
+      newAnchors,
+      totalAnchorCount: allAnchors.length,
       lastAnswers,
       chatNotes,
     });
@@ -398,10 +408,18 @@ async function runPanelAndChair(): Promise<void> {
         : next.requirements;
       const mergedVision =
         chairOutput.visionUpdate !== null ? chairOutput.visionUpdate : next.vision;
+      // Mark every anchor we just showed the Chair as seen — including
+      // the case where the Chair returned visionUpdate: null. The Chair
+      // had its chance; next round we want the next batch of anchors,
+      // not a re-show.
+      const mergedSeenAnchorIds = Array.from(
+        new Set([...next.seenAnchorIds, ...newAnchors.map((a) => a.id)]),
+      );
       return {
         ...next,
         requirements: mergedRequirements,
         vision: mergedVision,
+        seenAnchorIds: mergedSeenAnchorIds,
         pendingQuestions: chairOutput.questions,
         pendingChatNotes: [],
         searchesUsed: next.searchesUsed + searchesDispatched,

--- a/src/main/features/deepPlan/index.ts
+++ b/src/main/features/deepPlan/index.ts
@@ -26,11 +26,13 @@ import { oneShotPrompt } from './prompts';
 import { runPanelRound } from './panel';
 import { applyFallbackRequirementsPatch, runChair } from './chair';
 import { runChairChat } from './chat';
+import { DELEGATE_TO_RESEARCH } from '@shared/types';
 import {
   formatLookupReply,
   parseSourceLookups,
   resolveSourceLookups,
 } from '../sources/sourceLookup';
+import { dispatchDelegatedSearches } from './panel';
 
 /**
  * Deep Plan orchestrator. The flow is now:
@@ -256,6 +258,16 @@ export async function submitAnswers(answers: ChairAnswerMap): Promise<DeepPlanSt
   // moving instead of re-asking the same questions every round.
   const fallbackPatch = applyFallbackRequirementsPatch(answers);
 
+  // Detect delegated research: any pendingQuestion that carried a
+  // `delegableQuery` AND whose answer is the DELEGATE_TO_RESEARCH
+  // sentinel becomes a search to dispatch BEFORE the next panel round.
+  // We snapshot from the pre-clear session — pendingQuestions gets wiped
+  // in the updateSession call below.
+  const delegatedSearches = session.pendingQuestions
+    .filter((q) => typeof q.delegableQuery === 'string' && q.delegableQuery.length > 0)
+    .filter((q) => answers[q.id] === DELEGATE_TO_RESEARCH)
+    .map((q) => ({ query: q.delegableQuery!, rationale: q.prompt }));
+
   await updateSession((s) => {
     const withAnswers = appendMessage(
       s,
@@ -277,6 +289,28 @@ export async function submitAnswers(answers: ChairAnswerMap): Promise<DeepPlanSt
     log('deep-plan', 'submitAnswers.fallbackPatchApplied', { fields: Object.keys(fallbackPatch) });
   }
   notifyChanged();
+
+  // Dispatch delegated searches BEFORE firing the next panel round so the
+  // panel + Chair see any new sources in their context. Fire-and-forget
+  // would race the panel start; we await dispatch first, then kick the
+  // round.
+  if (delegatedSearches.length > 0) {
+    log('deep-plan', 'submitAnswers.delegated', {
+      queries: delegatedSearches.length,
+    });
+    try {
+      const { dispatched } = await dispatchDelegatedSearches(delegatedSearches);
+      if (dispatched > 0) {
+        await updateSession((s) => ({
+          ...s,
+          searchesUsed: s.searchesUsed + dispatched,
+        }));
+      }
+    } catch (err) {
+      logError('deep-plan', 'submitAnswers.delegated.failed', err);
+    }
+    notifyChanged();
+  }
 
   void runPanelAndChair().catch((err) => {
     logError('deep-plan', 'panel.submitAnswers.failed', err);
@@ -363,16 +397,15 @@ async function runPanelAndChair(): Promise<void> {
     // the round so they don't bleed into the next one.
     const chatNotes = [...session.pendingChatNotes];
 
-    const { panelOutputs, newlyIngestedSourceSlugs, searchesDispatched } = await runPanelRound({
-      session,
-      sources,
-      lastChairSummary: lastSummary,
-      lastAnswers,
-      chatNotes,
-    });
+    const { panelOutputs, newlyIngestedSourceSlugs, autoSearchesDispatched } =
+      await runPanelRound({
+        session,
+        sources,
+        lastChairSummary: lastSummary,
+        lastAnswers,
+        chatNotes,
+      });
 
-    // If the panel pulled in new sources, re-read the wiki so downstream
-    // resolvers + the Chair see them.
     const sourcesForChair =
       newlyIngestedSourceSlugs.length > 0 ? await listSources() : sources;
 
@@ -422,7 +455,7 @@ async function runPanelAndChair(): Promise<void> {
         seenAnchorIds: mergedSeenAnchorIds,
         pendingQuestions: chairOutput.questions,
         pendingChatNotes: [],
-        searchesUsed: next.searchesUsed + searchesDispatched,
+        searchesUsed: next.searchesUsed + autoSearchesDispatched,
         roundsPerPhase: {
           ...next.roundsPerPhase,
           [next.phase]: (next.roundsPerPhase[next.phase] ?? 0) + 1,

--- a/src/main/features/deepPlan/panel.ts
+++ b/src/main/features/deepPlan/panel.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { IpcChannels } from '@shared/ipc-channels';
 import {
-  DEEP_PLAN_MAX_SEARCHES_PER_ROUND,
   DEEP_PLAN_MAX_TOTAL_SEARCHES,
   PANEL_ROLES_BY_PHASE,
   type ChairAnswerMap,
@@ -21,14 +20,22 @@ import { ensureSearchReady } from '../research/search';
 import { panelistPrompt } from './prompts';
 import { parsePanelOutput } from './parse';
 
+export interface DelegatedSearch {
+  query: string;
+  rationale: string;
+}
+
 /**
  * Panel runner. One call per phase round:
  *   1. For each role in `PANEL_ROLES_BY_PHASE[phase]`, fan out a cheap-model
  *      JSON call in parallel.
- *   2. Merge + dedupe every role's `needsResearch[]`, cap at MAX_QUERIES,
- *      dispatch through the shared research engine.
- *   3. Return structured panel outputs + list of newly-ingested source
- *      slugs to hand to the Chair.
+ *   2. Return each panelist's vision notes + user-prompts (concerns /
+ *      questions / clarifications / ideas) for the Chair to synthesise.
+ *
+ * Search is no longer dispatched here — it's user-gated. Panelists propose
+ * research as `delegableQuery` riding on their user-prompts; the
+ * orchestrator dispatches when the user picks the "research this" answer
+ * option in `submitAnswers`.
  *
  * All progress events broadcast on `DeepPlan.PanelProgress` so the UI can
  * animate per-role status dots.
@@ -54,46 +61,6 @@ function digestPriorFindings(session: DeepPlanSession, limit = 12): string {
     .join('\n');
 }
 
-function normalizeQuery(q: string): string {
-  return q.trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-function mergeResearchRequests(
-  outputs: PanelOutput[],
-  cap: number,
-): PanelResearchRequest[] {
-  const merged: PanelResearchRequest[] = [];
-  if (cap <= 0) return merged;
-  const seen = new Set<string>();
-  for (const out of outputs) {
-    for (const req of out.needsResearch) {
-      const key = normalizeQuery(req.query);
-      if (!key || seen.has(key)) continue;
-      seen.add(key);
-      merged.push(req);
-      if (merged.length >= cap) return merged;
-    }
-  }
-  return merged;
-}
-
-function seedSeenUrls(sources: SourceMeta[]): Set<string> {
-  const seen = new Set<string>();
-  for (const src of sources) {
-    if (!src.sourcePath) continue;
-    try {
-      const u = new URL(src.sourcePath);
-      u.hash = '';
-      let path = u.pathname.replace(/\/+$/, '');
-      if (path === '') path = '/';
-      seen.add(`${u.protocol}//${u.host.toLowerCase()}${path}${u.search}`);
-    } catch {
-      seen.add(src.sourcePath.trim().toLowerCase());
-    }
-  }
-  return seen;
-}
-
 export interface PanelRoundArgs {
   session: DeepPlanSession;
   sources: SourceMeta[];
@@ -109,9 +76,10 @@ export interface PanelRoundArgs {
 
 export interface PanelRoundResult {
   panelOutputs: PanelOutput[];
+  /** Slugs of sources auto-dispatched + ingested by this round's `needsResearch`. */
   newlyIngestedSourceSlugs: string[];
-  /** Count of research queries actually dispatched this round (0 when budget is exhausted or panel didn't ask). */
-  searchesDispatched: number;
+  /** Count of auto-dispatched searches (excludes user-gated `delegableQuery` ones). */
+  autoSearchesDispatched: number;
 }
 
 async function runOnePanelist(
@@ -147,7 +115,7 @@ async function runOnePanelist(
   } catch (err) {
     logError('deep-plan', 'panel.role.failed', err, { role });
     emitProgress({ kind: 'role-failed', role, error: (err as Error).message });
-    return { role, visionNotes: '', needsResearch: [] };
+    return { role, visionNotes: '', userPrompts: [], needsResearch: [] };
   }
 
   if (!reply || reply.trim().length === 0) {
@@ -159,99 +127,58 @@ async function runOnePanelist(
       searchQueries: 0,
       visionNotes: '',
       needsResearch: [],
+      userPrompts: [],
     });
-    return { role, visionNotes: '', needsResearch: [] };
+    return { role, visionNotes: '', userPrompts: [], needsResearch: [] };
   }
 
   const output = parsePanelOutput(reply, role);
+  // searchQueries surfaced live = auto-fires + delegable proposals. The UI
+  // shows it as "N searches lined up" so the user sees activity ahead of
+  // time. The `needsResearch` payload mirrors auto-fire queries (they're
+  // about to run); delegable queries appear separately on userPrompts.
+  const delegableCount = output.userPrompts.filter((p) => p.delegableQuery).length;
+  const searchQueries = output.needsResearch.length + delegableCount;
   emitProgress({
     kind: 'role-done',
     role,
-    // `findings` stays as "did this role contribute anything" for the
-    // existing header stats. The actual content streams via
-    // `visionNotes` + `needsResearch` so the renderer can show the
-    // role's thought inline the moment it finishes — users see the
-    // panel's thinking live instead of waiting for the Chair to close
-    // the round.
     findings: output.visionNotes.trim().length > 0 ? 1 : 0,
-    searchQueries: output.needsResearch.length,
+    searchQueries,
     visionNotes: output.visionNotes,
     needsResearch: output.needsResearch,
+    userPrompts: output.userPrompts,
   });
   return output;
 }
 
-/**
- * Dispatch the merged research requests through the shared engine. Returns
- * the slugs that landed in the wiki during this dispatch (used by the
- * Chair to acknowledge newly-available evidence).
- */
-async function dispatchPanelResearch(
-  requests: PanelResearchRequest[],
-): Promise<string[]> {
-  if (requests.length === 0) return [];
+function normalizeQueryKey(q: string): string {
+  return q.trim().toLowerCase().replace(/\s+/g, ' ');
+}
 
-  try {
-    await ensureSearchReady();
-  } catch (err) {
-    logError('deep-plan', 'panel.research.searchNotReady', err);
-    return [];
+function mergeAutoResearch(
+  outputs: PanelOutput[],
+  cap: number,
+): PanelResearchRequest[] {
+  if (cap <= 0) return [];
+  const merged: PanelResearchRequest[] = [];
+  const seen = new Set<string>();
+  for (const out of outputs) {
+    for (const req of out.needsResearch) {
+      const key = normalizeQueryKey(req.query);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      merged.push(req);
+      if (merged.length >= cap) return merged;
+    }
   }
-
-  emitProgress({ kind: 'research-dispatched', queries: requests.length });
-
-  const newlyIngested: string[] = [];
-  const existingSources = await listSources();
-  const seen = seedSeenUrls(existingSources);
-
-  // The engine expects a `getNextPlan` that returns one batch of
-  // proposals. We already have a fixed, pre-curated list from the panel,
-  // so we return it once and then return an empty array to converge.
-  let served = false;
-  try {
-    await runResearchEngine(
-      {
-        runId: randomUUID(),
-        source: 'deepPlan',
-        getNextPlan: async () => {
-          if (served) return [];
-          served = true;
-          return requests.map((r) => ({ query: r.query, rationale: r.rationale }));
-        },
-        getHints: () => [],
-        isCancelled: () => false,
-        onQueryComplete: async (_proposal, _queryId, ingested) => {
-          for (const r of ingested) {
-            // `r.url` is the original URL; the engine persists digests
-            // using whatever slug the digest step produces. We can't
-            // easily recover that slug here without re-reading sources,
-            // so we take a snapshot after the engine finishes instead.
-            void r;
-          }
-        },
-      },
-      seen,
-    );
-  } catch (err) {
-    logError('deep-plan', 'panel.research.failed', err);
-    return [];
-  }
-
-  // Diff sources list: anything present now that wasn't before is a
-  // newly-ingested slug for this round.
-  const afterSources = await listSources();
-  const existingSlugs = new Set(existingSources.map((s) => s.slug));
-  for (const s of afterSources) {
-    if (!existingSlugs.has(s.slug)) newlyIngested.push(s.slug);
-  }
-  return newlyIngested;
+  return merged;
 }
 
 export async function runPanelRound(args: PanelRoundArgs): Promise<PanelRoundResult> {
   const phase = args.session.phase;
   const roles = PANEL_ROLES_BY_PHASE[phase];
   if (roles.length === 0) {
-    return { panelOutputs: [], newlyIngestedSourceSlugs: [], searchesDispatched: 0 };
+    return { panelOutputs: [], newlyIngestedSourceSlugs: [], autoSearchesDispatched: 0 };
   }
 
   emitProgress({ kind: 'round-start', phase, roles });
@@ -262,15 +189,14 @@ export async function runPanelRound(args: PanelRoundArgs): Promise<PanelRoundRes
     0,
     DEEP_PLAN_MAX_TOTAL_SEARCHES - args.session.searchesUsed,
   );
-  const perRoundCap = Math.min(DEEP_PLAN_MAX_SEARCHES_PER_ROUND, remainingBudget);
+  // No per-round artificial cap — panelists self-regulate via the
+  // soft-target prompt. Only the session-wide budget gates dispatch.
+  const perRoundCap = remainingBudget;
 
   // Run panelists with a concurrency cap. Each phase has at most 4 roles
   // (ideation 3, planning 4, reviewing 4), so a cap of 5 effectively runs
   // the whole phase in parallel — fastest path when backend rate limits
-  // have headroom. If a 429 does slip through under load, the
-  // `fetchWithRetryOn429` wrapper on every LLM call absorbs it, so we
-  // keep full parallelism here. Drop this back to 2–3 if backend limits
-  // start biting again.
+  // have headroom.
   const PANEL_CONCURRENCY = 5;
   const panelOutputs: PanelOutput[] = [];
   for (let i = 0; i < roles.length; i += PANEL_CONCURRENCY) {
@@ -283,14 +209,27 @@ export async function runPanelRound(args: PanelRoundArgs): Promise<PanelRoundRes
     panelOutputs.push(...batchResults);
   }
 
-  const researchRequests = mergeResearchRequests(panelOutputs, perRoundCap);
-  const newlyIngestedSourceSlugs = await dispatchPanelResearch(researchRequests);
+  // Auto-dispatch the panel's `needsResearch` lane. These are queries the
+  // panel decided fire regardless of user input — bounded by the per-round
+  // cap so we don't blow the search budget when multiple panelists pile on.
+  // The user-gated `delegableQuery` lane runs separately, in `submitAnswers`.
+  const autoSearches = mergeAutoResearch(panelOutputs, perRoundCap);
+  let newlyIngestedSourceSlugs: string[] = [];
+  if (autoSearches.length > 0) {
+    const { newlyIngestedSlugs } = await dispatchDelegatedSearches(autoSearches);
+    newlyIngestedSourceSlugs = newlyIngestedSlugs;
+  }
 
   log('deep-plan', 'panel.round.done', {
     phase,
     roles: roles.length,
     totalVisionNotes: panelOutputs.filter((p) => p.visionNotes.trim().length > 0).length,
-    researchDispatched: researchRequests.length,
+    totalUserPrompts: panelOutputs.reduce((sum, p) => sum + p.userPrompts.length, 0),
+    autoSearches: autoSearches.length,
+    delegableQueries: panelOutputs.reduce(
+      (sum, p) => sum + p.userPrompts.filter((u) => u.delegableQuery).length,
+      0,
+    ),
     newlyIngested: newlyIngestedSourceSlugs.length,
     remainingBudget,
   });
@@ -298,6 +237,94 @@ export async function runPanelRound(args: PanelRoundArgs): Promise<PanelRoundRes
   return {
     panelOutputs,
     newlyIngestedSourceSlugs,
-    searchesDispatched: researchRequests.length,
+    autoSearchesDispatched: autoSearches.length,
   };
+}
+
+function seedSeenUrls(sources: SourceMeta[]): Set<string> {
+  const seen = new Set<string>();
+  for (const src of sources) {
+    if (!src.sourcePath) continue;
+    try {
+      const u = new URL(src.sourcePath);
+      u.hash = '';
+      let path = u.pathname.replace(/\/+$/, '');
+      if (path === '') path = '/';
+      seen.add(`${u.protocol}//${u.host.toLowerCase()}${path}${u.search}`);
+    } catch {
+      seen.add(src.sourcePath.trim().toLowerCase());
+    }
+  }
+  return seen;
+}
+
+function normalizeQuery(q: string): string {
+  return q.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Dispatch a list of user-delegated research queries through the shared
+ * engine. Called from the orchestrator after `submitAnswers` detects the
+ * `DELEGATE_TO_RESEARCH` sentinel on questions with `delegableQuery` —
+ * not from the panel itself, since search is no longer autonomous.
+ *
+ * Returns `{ slugs, dispatched }` so the caller can credit
+ * `searchesUsed` and pass new sources to the Chair.
+ */
+export async function dispatchDelegatedSearches(
+  queries: DelegatedSearch[],
+): Promise<{ newlyIngestedSlugs: string[]; dispatched: number }> {
+  const dedup: DelegatedSearch[] = [];
+  const seen = new Set<string>();
+  for (const q of queries) {
+    const key = normalizeQuery(q.query);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    dedup.push(q);
+  }
+  if (dedup.length === 0) return { newlyIngestedSlugs: [], dispatched: 0 };
+
+  try {
+    await ensureSearchReady();
+  } catch (err) {
+    logError('deep-plan', 'delegated.search.notReady', err);
+    return { newlyIngestedSlugs: [], dispatched: 0 };
+  }
+
+  emitProgress({ kind: 'research-dispatched', queries: dedup.length });
+
+  const existingSources = await listSources();
+  const seenUrls = seedSeenUrls(existingSources);
+  let served = false;
+  try {
+    await runResearchEngine(
+      {
+        runId: randomUUID(),
+        source: 'deepPlan',
+        getNextPlan: async () => {
+          if (served) return [];
+          served = true;
+          return dedup.map((r) => ({ query: r.query, rationale: r.rationale }));
+        },
+        getHints: () => [],
+        isCancelled: () => false,
+        onQueryComplete: async () => {
+          /* no-op — we diff sources after the engine returns */
+        },
+      },
+      seenUrls,
+    );
+  } catch (err) {
+    logError('deep-plan', 'delegated.search.failed', err);
+    return { newlyIngestedSlugs: [], dispatched: dedup.length };
+  }
+
+  const after = await listSources();
+  const existingSlugs = new Set(existingSources.map((s) => s.slug));
+  const newlyIngestedSlugs = after.filter((s) => !existingSlugs.has(s.slug)).map((s) => s.slug);
+  log('deep-plan', 'delegated.search.done', {
+    dispatched: dedup.length,
+    newlyIngested: newlyIngestedSlugs.length,
+  });
+  return { newlyIngestedSlugs, dispatched: dedup.length };
 }

--- a/src/main/features/deepPlan/parse.ts
+++ b/src/main/features/deepPlan/parse.ts
@@ -231,6 +231,12 @@ function sanitizeRequirementsPatch(item: unknown): Partial<PlanRequirements> | n
     ? String(rec.styleNotes ?? rec.style_notes).trim()
     : '';
   if (notes) patch.styleNotes = notes;
+  const framework = typeof rec.framework === 'string' ? rec.framework.trim() : '';
+  if (framework) patch.framework = framework;
+  const deliverableRaw =
+    rec.deliverableFormat ?? rec.deliverable_format ?? rec.deliverable;
+  const deliverable = typeof deliverableRaw === 'string' ? deliverableRaw.trim() : '';
+  if (deliverable) patch.deliverableFormat = deliverable;
   return Object.keys(patch).length > 0 ? patch : null;
 }
 

--- a/src/main/features/deepPlan/parse.ts
+++ b/src/main/features/deepPlan/parse.ts
@@ -6,6 +6,8 @@ import type {
   PanelOutput,
   PanelResearchRequest,
   PanelRole,
+  PanelUserPrompt,
+  PanelUserPromptKind,
   PlanRequirements,
 } from '@shared/types';
 
@@ -117,6 +119,27 @@ function strOr(v: unknown, fallback = ''): string {
   return typeof v === 'string' ? v.trim() : fallback;
 }
 
+const VALID_PROMPT_KINDS: readonly PanelUserPromptKind[] = [
+  'concern',
+  'question',
+  'clarification',
+  'idea',
+];
+
+function sanitizeUserPrompt(item: unknown): PanelUserPrompt | null {
+  if (!item || typeof item !== 'object') return null;
+  const rec = item as Record<string, unknown>;
+  const prompt = strOr(rec.prompt);
+  if (!prompt) return null;
+  const kindRaw = strOr(rec.kind).toLowerCase() as PanelUserPromptKind;
+  const kind: PanelUserPromptKind = VALID_PROMPT_KINDS.includes(kindRaw) ? kindRaw : 'question';
+  const rationale = strOr(rec.rationale);
+  const out: PanelUserPrompt = { kind, prompt, rationale };
+  const delegableQuery = strOr(rec.delegableQuery ?? rec.delegable_query ?? rec.query);
+  if (delegableQuery) out.delegableQuery = delegableQuery;
+  return out;
+}
+
 function sanitizePanelResearch(item: unknown): PanelResearchRequest | null {
   if (!item || typeof item !== 'object') return null;
   const rec = item as Record<string, unknown>;
@@ -127,12 +150,23 @@ function sanitizePanelResearch(item: unknown): PanelResearchRequest | null {
 
 export function parsePanelOutput(raw: string, role: PanelRole): PanelOutput {
   const parsed = extractJsonBlob(raw);
+  const userPrompts: PanelUserPrompt[] = [];
   const needsResearch: PanelResearchRequest[] = [];
   let visionNotes = '';
 
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     const rec = parsed as Record<string, unknown>;
     visionNotes = strOr(rec.visionNotes ?? rec.vision_notes);
+    const promptSource =
+      (Array.isArray(rec.userPrompts) && rec.userPrompts) ||
+      (Array.isArray(rec.user_prompts) && rec.user_prompts) ||
+      null;
+    if (promptSource) {
+      for (const item of promptSource) {
+        const p = sanitizeUserPrompt(item);
+        if (p) userPrompts.push(p);
+      }
+    }
     const researchSource =
       (Array.isArray(rec.needsResearch) && rec.needsResearch) ||
       (Array.isArray(rec.needs_research) && rec.needs_research) ||
@@ -145,10 +179,17 @@ export function parsePanelOutput(raw: string, role: PanelRole): PanelOutput {
     }
   }
 
+  // Sanity backstops — the panelist prompt sets the real targets and
+  // teaches the model when to push higher / lower. Cap auto-search HARD
+  // at 1 per panelist: the panel runs in parallel, so a 1-each cap keeps
+  // total round volume to ~one-per-panelist worst case (most should
+  // emit 0 anyway). User-prompts get more headroom since they cost
+  // nothing — Chair curates them down to 2–3 surfaced.
   return {
     role,
     visionNotes: visionNotes.slice(0, 500),
-    needsResearch: needsResearch.slice(0, 2),
+    userPrompts: userPrompts.slice(0, 3),
+    needsResearch: needsResearch.slice(0, 1),
   };
 }
 
@@ -206,6 +247,19 @@ function sanitizeChairQuestion(item: unknown, index: number): ChairQuestion | nu
 
   const out: ChairQuestion = { id, type, prompt, choices, rationale };
   if (allowCustom && type === 'choice') out.allowCustom = true;
+  const delegableQuery = strOr(rec.delegableQuery ?? rec.delegable_query);
+  if (delegableQuery) out.delegableQuery = delegableQuery;
+  const proposedByRaw = strOr(rec.proposedBy ?? rec.proposed_by).toLowerCase();
+  if (proposedByRaw) {
+    const validRoles: readonly string[] = [
+      'explorer', 'scoper', 'stakes', 'architect', 'evidence',
+      'steelman', 'skeptic', 'adversary', 'editor', 'audience', 'finaliser',
+      'chair',
+    ];
+    if (validRoles.includes(proposedByRaw)) {
+      out.proposedBy = proposedByRaw as ChairQuestion['proposedBy'];
+    }
+  }
   return out;
 }
 
@@ -275,7 +329,7 @@ export function parseChairOutput(raw: string): ChairOutput | null {
   return {
     summary,
     visionUpdate,
-    questions: questions.slice(0, 3),
+    questions: questions.slice(0, 6),
     phaseAdvance,
     requirementsPatch,
   };

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -428,7 +428,16 @@ export function panelistPrompt(role: PanelRole, ctx: PanelContext): string {
 
 **Search is per-claim, not per-session** — do NOT suppress because the wiki has sources from earlier rounds. Coverage is judged PER SUB-CLAIM. A wiki of 8 sources isn't "enough" if this round's specific concern isn't covered. Re-evaluate from scratch each round. But: also don't fire just because we haven't searched yet this round — fire only when YOUR lens has a real, sharp gap.
 
-Default to \`needsResearch\` when the literature is the bottleneck. Default to \`userPrompts.delegableQuery\` only when the writer's preference picks the search direction. Session budget: ${DEEP_PLAN_MAX_TOTAL_SEARCHES} total.`
+**DECOUPLE concerns from searches.** A concern in \`userPrompts\` and a search in \`needsResearch\` are INDEPENDENT lanes — you can fire both. If you have a concern AND a literature-side gap on the same topic:
+- Concern → \`userPrompts\` (no \`delegableQuery\`).
+- Search → \`needsResearch\` (auto-fires).
+Don't bundle them into one \`userPrompts\` with a \`delegableQuery\` just because they touch the same theme. Test: if the writer's answer to your concern wouldn't change WHICH search you'd run, the search belongs in \`needsResearch\`. Bundling forces the writer to click "research this" for a search that should have just fired.
+
+Worked example: your concern is "how do we prevent reward hacking from the heuristic bonus?" and you also want to search "reward hacking heuristic bonuses rlhf". The writer's answer doesn't change whether the literature is worth fetching — so:
+- \`userPrompts\`: \`{kind: "concern", prompt: "How do we prevent…", rationale: "…"}\` — NO delegableQuery.
+- \`needsResearch\`: \`[{query: "reward hacking heuristic bonuses rlhf", rationale: "…"}]\` — fires automatically.
+
+Default to \`needsResearch\` when the literature is the bottleneck. Default to \`userPrompts.delegableQuery\` only when the writer's preference picks the search direction (mutually exclusive search options). Session budget: ${DEEP_PLAN_MAX_TOTAL_SEARCHES} total.`
     : `The session search budget is exhausted — emit \`needsResearch: []\` and do NOT attach \`delegableQuery\` to any user-prompt. Work with the wiki and vision you already have.`;
 
   return `You are ONE voice on a vision-steering panel. You do NOT write the draft. You do NOT curate anchors — extraction is deterministic at ingest time. Your three outputs each round:

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -2,6 +2,7 @@ import type {
   AnchorLogEntry,
   ChairAnswerMap,
   ChairQuestion,
+  DeepPlanMode,
   DeepPlanPhase,
   DeepPlanSession,
   PanelOutput,
@@ -54,6 +55,95 @@ function missingRequirements(req: PlanRequirements): string[] {
   if (!req.form) missing.push('form');
   if (!req.audience) missing.push('audience');
   return missing;
+}
+
+/**
+ * Mode-specific guidance the Chair uses to shape vision.md. Different
+ * deliverables want different vision shapes — an idea-exploration vision
+ * is "the concept + open questions + directions", not "thesis + sub-claims".
+ * Returned blocks are appended to the Chair's vision rules.
+ */
+function chairModeBlock(mode: DeepPlanMode): string {
+  switch (mode) {
+    case 'idea-exploration':
+      return `\n\nMODE — IDEA EXPLORATION:
+The writer has a half-baked CONCEPT (not a thesis). Vision's spine is the IDEA itself, not an argument. The vision should carry:
+- **The concept** — one or two sentences naming what the idea actually is.
+- **Prior art** — what's already been tried or proposed in this space (anchors here are gold).
+- **Strengths** — what the concept does that prior art doesn't.
+- **Weaknesses / open questions** — where the idea is fragile or under-specified.
+- **Directions** — concrete forms the concept could take (a paper, a prototype, an experiment).
+Do NOT manufacture a thesis. The drafter is going to PRESSURE-TEST and DEVELOP the idea, not defend it as established.`;
+    case 'literature-review':
+      return `\n\nMODE — LITERATURE REVIEW:
+Vision's spine is the SET OF SOURCES being reviewed and the SYNTHESIS lens. Carry:
+- **Scope** — what counts as in/out of the review.
+- **Per-source intent** — for each major source, one line on what the review will say about it (relevance, strength, weakness).
+- **Cross-cutting themes** — what synthesis emerges across sources.
+- **Evaluation criteria** — what dimensions the review judges sources on (audience fit, methodology, evidence quality).
+A review's "thesis" is the synthesis verdict, not a single argumentative claim.`;
+    case 'analytical-report':
+      return `\n\nMODE — ANALYTICAL REPORT:
+Vision's spine is the OBSERVATIONAL/ANALYTICAL FINDING. Carry:
+- **Question** — what the report is trying to answer.
+- **Method** — how the analysis was/is conducted (data sources, framework, tooling).
+- **Headline findings** — the 2–4 specific claims the analysis supports.
+- **Caveats** — limits of the data and the inference.
+The "thesis" is the headline finding; the body is the evidence trail that supports it.`;
+    case 'comparative-analysis':
+      return `\n\nMODE — COMPARATIVE ANALYSIS:
+Vision's spine is the COMPARISON ITSELF. Carry:
+- **Subjects** — what's being compared (2+ specific things).
+- **Criteria** — the explicit dimensions of comparison (3–6 criteria).
+- **Verdict per criterion** — one line on which subject wins / fails on each.
+- **Overall judgment** — the synthesis claim the piece lands on.
+The "thesis" is the verdict — defensible across the criteria.`;
+    case 'argumentative-essay':
+    default:
+      return '';
+  }
+}
+
+/**
+ * Mode-specific structural template the drafter uses. Returns the H2
+ * skeleton + per-section guidance. Empty when mode is the default essay.
+ */
+function drafterModeBlock(mode: DeepPlanMode): string {
+  switch (mode) {
+    case 'idea-exploration':
+      return `\n\nDELIVERABLE MODE — IDEA EXPLORATION:
+This is NOT an essay defending the idea as established. The user has a CONCEPT and wants you to pressure-test and develop it. Treat the idea as the SUBJECT.
+Output structure (H1 = the concept's name; H2s in this order):
+- \`## The concept\` — one or two paragraphs naming what the idea actually is. Cite reference anchors when defining adjacent prior concepts.
+- \`## Prior art\` — what's been tried, proposed, or written on this space. This is where most reference citations land. Be specific — name the precedent, what it did, where it stops short of the user's idea.
+- \`## Strengths\` — what the concept does that prior art doesn't. Make the case CONCRETELY, with mechanisms not vibes.
+- \`## Weaknesses and open questions\` — where the idea is fragile. SHARP objections, not obvious ones. Cite anchors that surface concerns.
+- \`## Directions\` — 3–5 concrete forms the concept could take next: a paper, an experiment, a tool, a refinement. Each direction names what would be needed to develop it.
+- \`## References\` — Harvard-style, only sources cited inline.
+Do NOT manufacture a thesis statement. Do NOT write "this paper argues that…" — you're not arguing the idea is right; you're surveying its space and surfacing what's interesting.`;
+    case 'literature-review':
+      return `\n\nDELIVERABLE MODE — LITERATURE REVIEW:
+Output structure: brief Introduction → one section per major source (Article 1, Article 2, …) each with sub-headings Introduction / Summary / Analysis / Conclusion → Final Synthesis comparing the sources → References.
+Per-source Analysis sub-section is the heaviest — that's where you EVALUATE the source against the assignment's criteria (audience fit, methodology, evidence quality, alignment with established frameworks, practical utility, limitations) using SPECIFIC details from that source. Generic comments about "the literature" are a failure.
+Cross-cite to other sources only in the Final Synthesis. Each per-source section should mostly cite its own anchors.`;
+    case 'analytical-report':
+      return `\n\nDELIVERABLE MODE — ANALYTICAL REPORT:
+Output structure (H1 = the report's title; H2s in this order):
+- \`## Introduction\` — question, scope, why it matters.
+- \`## Method\` — data sources used, analytical framework, tooling. Low-citation; describes process.
+- \`## Findings\` — the headline findings, each in its own H3 sub-section if there are multiple. Specific numbers, mechanisms, examples. This is where reference anchors carry their weight.
+- \`## Discussion\` — interpretation, implications, caveats, limits. Contextualises findings against literature.
+- \`## References\` — Harvard-style, only sources cited inline.
+When raw-source files (CSV/code/JSON) are part of the wiki, the Findings section should reference them directly when interpreting numerical results.`;
+    case 'comparative-analysis':
+      return `\n\nDELIVERABLE MODE — COMPARATIVE ANALYSIS:
+Output structure: brief Introduction setting up subjects + criteria → body organised EITHER by criterion (one H2 per criterion, comparing subjects within each) OR by subject (one H2 per subject, walking criteria within each) — pick the structure that lets the verdict land harder → Overall Judgment H2 → References.
+Pick by-criterion when criteria are the more important axis (a head-to-head). Pick by-subject when each subject is best understood holistically before comparison. State your structural choice in the Introduction.
+Each criterion's discussion must REACH A VERDICT — "subject A wins on X because Y" — not just describe both sides neutrally.`;
+    case 'argumentative-essay':
+    default:
+      return '';
+  }
 }
 
 /**
@@ -379,6 +469,15 @@ export interface ChairPromptArgs {
   roundNumber: number;
   sources: SourceMeta[];
   /**
+   * Anchors the Chair hasn't been shown yet (filtered against
+   * `session.seenAnchorIds` upstream). The full anchor universe lives on
+   * disk; we only render the new ones here so context stays tight as the
+   * wiki grows AND so vision updates are forced to ground in fresh evidence.
+   */
+  newAnchors: AnchorLogEntry[];
+  /** Total anchor count across the wiki — for the "you've seen N already" line. */
+  totalAnchorCount: number;
+  /**
    * Answers the user submitted to the PREVIOUS round's Chair questions.
    * Crucial for emitting `requirementsPatch` — without this the Chair has
    * no way to know what the user picked for word count / form / audience
@@ -393,12 +492,51 @@ export interface ChairPromptArgs {
   chatNotes: string[];
 }
 
+/**
+ * Render the Chair-facing anchor block. Compact: each new anchor shows
+ * its citation tag, slug fragment, and verbatim text — same format the
+ * drafter sees, so the Chair can write vision bullets like
+ *   "- The plausibility trap (see Smith, 2022#step-3-failure)"
+ * and the drafter recognises the pointer.
+ */
+function chairAnchorsBlock(newAnchors: AnchorLogEntry[], totalCount: number): string {
+  const seen = totalCount - newAnchors.length;
+  const seenLine =
+    seen > 0
+      ? ` You've already been shown ${seen} anchor${seen === 1 ? '' : 's'} in prior rounds — they remain in scope but are omitted here to keep context tight.`
+      : '';
+  if (newAnchors.length === 0) {
+    return totalCount === 0
+      ? '_(no anchors yet — sources have not been ingested or extraction is pending)_'
+      : `_(no NEW anchors this round.${seenLine})_`;
+  }
+  const renderEntry = (e: AnchorLogEntry, i: number): string => {
+    const anchorFrag = e.id.split('#')[1] ?? '';
+    const tag = citationTag(e);
+    const roleTag = e.role === 'guidance' ? ' [guidance — apply, do not cite]' : '';
+    const head = `${i + 1}. [${e.type}]${roleTag} \`(${tag})\` → \`${e.slug}.md#${anchorFrag}\``;
+    const body = `\n   "${e.text.replace(/\n+/g, ' ').trim()}"`;
+    return `${head}${body}`;
+  };
+  return `${newAnchors.length} NEW anchor${newAnchors.length === 1 ? '' : 's'} since last round (of ${totalCount} total in the wiki).${seenLine}\n\n${newAnchors.map(renderEntry).join('\n')}`;
+}
+
 export function chairPrompt(args: ChairPromptArgs): string {
   // The Chair reads the rubric, vision, panel notes, chat notes, recent
   // history, and a simple source list. It no longer sees an anchor log
   // or curates anchors — extraction happens at ingest time and anchors
   // flow straight to the drafter.
-  const { session, panelOutputs, newlyIngestedSourceSlugs, roundNumber, sources, lastAnswers, chatNotes } = args;
+  const {
+    session,
+    panelOutputs,
+    newlyIngestedSourceSlugs,
+    roundNumber,
+    sources,
+    newAnchors,
+    totalAnchorCount,
+    lastAnswers,
+    chatNotes,
+  } = args;
   const phase = session.phase;
   const priorSummaries = priorChairDigest(session);
   const missing = missingRequirements(session.requirements);
@@ -455,10 +593,14 @@ ${requirementsBlock(session.requirements)}${requirementsGap}${lastAnswersSection
 
 ${searchBudgetBlock(session)}
 
-Wiki — sources ingested so far (anchors extracted from these flow to the drafter automatically — you do not need to reference specific anchors):
+Wiki — sources ingested so far (one-line summaries; the anchors below are the actual evidence pile):
 ${sourcesBlock(sources)}
 
-CURRENT VISION.md (your existing intellectual spine — rewrite it this round only if the panel notes + chat notes + new sources genuinely move thesis/POV/section intents):
+NEW ANCHORS this round — these are the verbatim source statements you have NOT yet been shown. When you update the vision, every novel insight should either point at one of these (or a previously-seen anchor by name) or name a concrete mechanism. Abstract bullets that do neither get cut.
+
+${chairAnchorsBlock(newAnchors, totalAnchorCount)}
+
+CURRENT VISION.md (your existing intellectual spine — rewrite it this round only if the panel notes + chat notes + new anchors genuinely move thesis/POV/section intents):
 ${visionBlock(session.vision)}
 
 Panel vision-notes + research this round:
@@ -498,13 +640,17 @@ VISION.md rules:
 - What belongs in vision, roughly in priority order:
   1. **Thesis** — the single claim the piece makes, one or two sentences.
   2. **POV / angle** — the lens. Why THIS take, not a textbook summary?
-  3. **Novel insights** — the ideas the writer + Chair surfaced in conversation that don't live in any one source. The core of the piece.
-  4. **Counter-argument to engage** — the strongest opposing position, stated in one line.
-  5. **What this piece is NOT** — scope-setting; what you deliberately chose to leave out.
+  3. **Novel insights** — the ideas the writer + Chair surfaced that don't live in any one source. EACH insight must either (a) point at a specific anchor by source name + id (e.g. "see Smith, 2022#step-3-failure"), or (b) name a concrete mechanism. Abstractions without either get cut. If two insights collapse to the same underlying claim, MERGE them.
+  4. **Counter-argument to engage** — the SHARP objection, the one that would change a thoughtful expert's mind. The first objection that comes to mind (cost, efficiency, performance) is rarely the right one — skip it when a more incisive objection (one that turns the thesis's own logic against itself) exists. State it in one line.
+  5. **What this piece argues AGAINST** — name the position, framing, or assumption this piece is contesting. Not "what this piece is NOT" (descriptive scope-fencing); name the belief the writer is contradicting. A vision without an antagonist drifts toward textbook summary.
   6. **Section arc** *(light touch, not a heading outline)* — a single line or brief bullet list naming 3–6 beats in reading order, phrased as intents ("open with the decomposition", "pivot to the distributional critique", "land on what the concept can and cannot do"). This seeds the drafter's H2s; the drafter writes the actual section titles at draft time.
 - The section arc is one line in the vision, not its own major section with sub-bullets. If you find yourself writing more than a line per beat, you're drifting into plan-rewrite territory.
 - \`visionUpdate: null\` is the right call on rounds where nothing substantive shifted. Don't rewrite vision just to rewrite it — small churn is noise.
-- When you DO rewrite vision, you're rewriting the WHOLE thing in full (no patches). Preserve what still holds; sharpen what just moved.
+- When you DO rewrite vision, you're rewriting the WHOLE thing in full (no patches). Preserve what still holds; sharpen what just moved.${chairModeBlock(session.mode)}
+
+Pre-emit micro-check (run BEFORE finalising visionUpdate):
+- For each LOAD-BEARING term in the vision (proper noun, coined phrase, named framework), is it defined inline OR grounded in a specific anchor? If neither, drop the term or replace with the concrete description it stands for. A thesis that hinges on an undefined coined term is a vibes thesis.
+- For each "Novel insight", could the drafter unpack it into 200 words of specific prose without making things up? If not, the insight is a wishbone — sharpen or drop.
 
 Question rules:
 - **FIRST PRIORITY — missing hard requirements.** If the rubric above lists any field as "(not specified)" (especially word count), ask about them THIS ROUND. Use \`choice\` with 3–4 reasonable defaults and mark one \`recommended\`. Example for word count: {1000–1500, 1500–2500, 2500–4000, custom with \`allowCustom: true\`}.
@@ -763,7 +909,7 @@ export function oneShotPrompt(
 
 5. **HONOUR THE WORD-COUNT RANGE.** Going over or under by more than 10% is a failure. ${wordCountLine}
 
-6. **STRUCTURE WITH HEADINGS.** Every draft opens with a \`# Title\` H1 and breaks the body into \`## Section\` H2s. Section titles tell the reader what the section ARGUES, not just what topic it covers. A wall of unbroken prose with no H2s is a shipping failure.
+6. **STRUCTURE WITH HEADINGS.** Every draft opens with a \`# Title\` H1 and breaks the body into \`## Section\` H2s. When the deliverable mode below specifies an H2 list, USE IT VERBATIM. Otherwise pick H2s that argue rather than label. A wall of unbroken prose with no H2s is a shipping failure.
 
 7. **APPLY USER-STATED CONSTRAINTS.** If the rubric names a framework or deliverable format, you MUST apply it. Writing about it instead of using it is a hard failure.
 
@@ -774,7 +920,7 @@ You are Myst, writing the first full draft of "${docLabel}" from a completed Dee
 User's task: "${session.task}"${constraintsLine}
 
 RUBRIC (HARD constraints — the draft is judged against these):
-${requirementsBlock(session.requirements)}${formatGuide}${frameworkGuide}${guidanceNote}
+${requirementsBlock(session.requirements)}${drafterModeBlock(session.mode)}${formatGuide}${frameworkGuide}${guidanceNote}
 
 VISION — the intellectual spine. Follow its thesis, POV, and section intents. The vision itself has no citations; it tells you WHAT to write.
 

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -56,6 +56,19 @@ function missingRequirements(req: PlanRequirements): string[] {
   return missing;
 }
 
+/**
+ * Render a one-line "user-stated constraints" header for prompts that
+ * benefit from a tight reminder of the framework + deliverable format
+ * (Chair, drafter). Returns empty string when neither is present.
+ */
+function userConstraintsLine(req: PlanRequirements): string {
+  const parts: string[] = [];
+  if (req.deliverableFormat) parts.push(`format: ${req.deliverableFormat}`);
+  if (req.framework) parts.push(`framework: ${req.framework}`);
+  if (parts.length === 0) return '';
+  return `User-stated constraints (HONOUR THESE — they came directly from the writer's brief): ${parts.join(' · ')}.`;
+}
+
 function requirementsBlock(req: PlanRequirements): string {
   const lengthLine = (() => {
     if (req.wordCountMin !== null && req.wordCountMax !== null) {
@@ -71,7 +84,9 @@ function requirementsBlock(req: PlanRequirements): string {
   return [
     lengthLine,
     `- Form: ${req.form ?? '(not specified)'}`,
+    `- Deliverable format: ${req.deliverableFormat ?? "(not specified — use the form's defaults)"}`,
     `- Audience: ${req.audience ?? '(not specified)'}`,
+    `- Framework / method to apply: ${req.framework ?? "(none — write in the writer's natural register)"}`,
     `- Style notes: ${req.styleNotes ?? '(none)'}`,
   ].join('\n');
 }
@@ -90,20 +105,56 @@ function visionBlock(vision: string): string {
 }
 
 /**
+ * Format the citation tag the drafter sees next to each anchor — what the
+ * model should literally type for the inline link's visible text. When
+ * bibliographic metadata is present, prefer Author-Date; otherwise fall back
+ * to the source name (clipped) so we never invent a fake author.
+ */
+function citationTag(e: AnchorLogEntry): string {
+  const bib = e.bibliographic;
+  if (bib?.author) {
+    return bib.year ? `${bib.author}, ${bib.year}` : bib.author;
+  }
+  // Source name fallback. Trim aggressively — long titles inside parens read
+  // like the drafter forgot to cite at all.
+  return e.sourceName.length > 40 ? `${e.sourceName.slice(0, 37)}…` : e.sourceName;
+}
+
+/**
  * Render the anchor log — the full flat list of every anchor across
  * every ingested source. Consumed by the drafter at handoff so the draft
- * grounds in the evidence.
+ * grounds in the evidence. Splits role:reference (cite these) from
+ * role:guidance (apply these as method, never cite). The split is what
+ * stops the drafter ending up with a reference list full of method
+ * guides — guidance anchors live in their own block with explicit
+ * "do not cite" wording.
  */
 function anchorLogBlock(anchors: AnchorLogEntry[]): string {
-  if (anchors.length === 0) return '_(no anchors extracted yet — ingest or research some sources first)_';
-  return anchors
+  if (anchors.length === 0) {
+    return '_(no anchors extracted yet — ingest or research some sources first)_';
+  }
+  const refs = anchors.filter((a) => (a.role ?? 'reference') === 'reference');
+  const guides = anchors.filter((a) => a.role === 'guidance');
+  const renderEntry = (e: AnchorLogEntry, i: number): string => {
+    const anchorFrag = e.id.split('#')[1] ?? '';
+    const tag = citationTag(e);
+    const head = `${i + 1}. [${e.type}] cite as \`(${tag})\` → \`${e.slug}.md#${anchorFrag}\``;
+    const body = `\n   "${e.text.replace(/\n+/g, ' ').trim()}"`;
+    return `${head}${body}`;
+  };
+  const refsBlock =
+    refs.length === 0
+      ? '_(no reference-role anchors yet — every claim in the draft will currently be unsourced. Flag this in the draft.)_'
+      : refs.map(renderEntry).join('\n');
+  if (guides.length === 0) return refsBlock;
+  const guidesBlock = guides
     .map((e, i) => {
-      const anchorFrag = e.id.split('#')[1] ?? '';
-      const head = `${i + 1}. [${e.type}] ([${e.sourceName}](${e.slug}.md#${anchorFrag}))`;
+      const head = `${i + 1}. [${e.type}] from "${e.sourceName}" — METHOD GUIDANCE, do not cite`;
       const body = `\n   "${e.text.replace(/\n+/g, ' ').trim()}"`;
       return `${head}${body}`;
     })
     .join('\n');
+  return `### Reference anchors — these are EVIDENCE you cite inline + list in References:\n${refsBlock}\n\n### Guidance anchors — these are METHOD instructions. INTERNALISE them as how to write; NEVER cite them inline; NEVER list them in References:\n${guidesBlock}`;
 }
 
 /**
@@ -114,7 +165,12 @@ function anchorLogBlock(anchors: AnchorLogEntry[]): string {
  */
 function sourcesBlock(sources: SourceMeta[]): string {
   if (sources.length === 0) return '_No sources yet._';
-  return sources.map((s) => `- **${s.name}** — ${s.indexSummary}`).join('\n');
+  return sources
+    .map((s) => {
+      const tag = (s.role ?? 'reference') === 'guidance' ? ' _[guidance]_' : '';
+      return `- **${s.name}**${tag} — ${s.indexSummary}`;
+    })
+    .join('\n');
 }
 
 function searchBudgetBlock(session: DeepPlanSession): string {
@@ -377,6 +433,8 @@ export function chairPrompt(args: ChairPromptArgs): string {
   const chatNotesSection = chatNotes.length > 0
     ? `\n\nUser's free-chat notes since the last panel round (the writer typed these between rounds — factor them into your summary AND into the plan rewrite where relevant):\n${chatNotes.map((n, i) => `${i + 1}. ${n}`).join('\n')}`
     : '';
+  const constraintsLine = userConstraintsLine(session.requirements);
+  const constraintsSection = constraintsLine ? `\n\n${constraintsLine}` : '';
 
   return `You are the CHAIR of a writing panel. The session has two artefacts you touch: a tiny rubric (hard constraints) and a small vision.md (intellectual spine). You do NOT touch the anchor log — anchors are extracted deterministically from each source at ingest time and flow straight to the drafter. Your job is to steer the vision, probe the user when a judgment call needs them, and update the rubric when the user's answers change it.
 
@@ -390,7 +448,7 @@ Phase intent:
 ${PHASE_INTENT[phase]}
 
 Current round in this phase: ${roundNumber}${advanceNudge}
-User's task: "${session.task}"
+User's task: "${session.task}"${constraintsSection}
 
 RUBRIC (hard constraints — the draft must honour these):
 ${requirementsBlock(session.requirements)}${requirementsGap}${lastAnswersSection}${chatNotesSection}
@@ -425,7 +483,9 @@ ${priorSummaries ? `Prior-round Chair summaries (do NOT repeat these — move th
   "requirementsPatch": {
     "wordCountMin": 1500, "wordCountMax": 2500,
     "form": "exploratory essay",
+    "deliverableFormat": "literature review",
     "audience": "general educated reader",
+    "framework": "Five Domains",
     "styleNotes": null
   } | null
 }
@@ -460,6 +520,8 @@ requirementsPatch rule:
 - When the user's last answers answered a question about a hard requirement, populate matching fields. The system shallow-merges this into session.requirements.
 - \`wordCountMin\` / \`wordCountMax\`: integers. Match what the user picked; if they delegated, use sensible defaults (essay: 1500–2500; blog post: 800–1500; report: 2500–4000).
 - \`form\`: short lowercase ("exploratory essay", "blog post", "op-ed", "report").
+- \`deliverableFormat\`: short lowercase format name when the user named a specific deliverable beyond the form ("literature review", "lab report", "policy memo", "case study analysis", "annotated bibliography"). Distinct from \`form\` — \`form\` is the basic shape; \`deliverableFormat\` is the structural template. Set when you confirm or extract one with the user; otherwise omit.
+- \`framework\`: when the user named a specific framework / method / theoretical lens to apply ("Five Domains", "CRAAP test", "STAR method", "Porter's Five Forces"). Echo it back verbatim with sensible casing. Do not invent one — only set when the user has explicitly named it.
 - \`audience\`: short lowercase ("general educated reader", "economists and policy professionals").
 - \`styleNotes\`: free text ONLY when the user stated specific style constraints. Otherwise null.
 - Emit null/omit when this round didn't touch hard requirements. Don't echo unchanged fields.
@@ -630,32 +692,89 @@ export function oneShotPrompt(
   docLabel: string,
   anchors: AnchorLogEntry[],
 ): string {
-  const anchorCount = anchors.length;
+  const refAnchors = anchors.filter((a) => (a.role ?? 'reference') === 'reference');
+  const guideAnchors = anchors.filter((a) => a.role === 'guidance');
+  const refCount = refAnchors.length;
   const anchorCountLine =
-    anchorCount === 0
-      ? 'ANCHOR LOG IS EMPTY. This is a failure state — the panel session should have produced evidence. Do NOT fabricate sources or citations. If the log is genuinely empty, write a short essay from the vision alone and flag the lack of evidence at the top.'
-      : `ANCHOR LOG contains ${anchorCount} entries. These are the ONLY sources you may cite. Every citation in the draft MUST be drawn from this list — never invent a source, never cite something that isn't here.`;
+    refCount === 0
+      ? 'REFERENCE-ROLE ANCHOR LOG IS EMPTY. This is a failure state — the panel session should have produced evidence. Do NOT fabricate sources or citations. If the log is genuinely empty, write a short essay from the vision alone and flag the lack of evidence at the top.'
+      : `REFERENCE-ROLE ANCHOR LOG contains ${refCount} entries. These are the ONLY sources you may cite inline and list in References. Every citation in the draft MUST be drawn from this list — never invent a source, never cite something that isn't here, NEVER cite a guidance-role anchor.`;
+  const constraints = userConstraintsLine(session.requirements);
+  const constraintsLine = constraints ? `\n\n${constraints}\n` : '';
+  const req = session.requirements;
+  const targetWords = req.wordCountMin ?? req.wordCountMax;
+  const wordCountLine = (() => {
+    if (req.wordCountMin && req.wordCountMax) {
+      const mid = Math.round((req.wordCountMin + req.wordCountMax) / 2);
+      return `Target the MIDDLE of the rubric range (${req.wordCountMin}–${req.wordCountMax}); aim for roughly ${mid} words. Under-shooting by 30% is the most common failure on this prompt — DO NOT stop early. If you find yourself near a natural conclusion before the word target, expand: deepen the analysis, add a counter-argument paragraph, unpack a claim with a specific example.`;
+    }
+    if (targetWords) {
+      return `Target ~${targetWords} words. Going noticeably under is a common failure — keep writing until you hit it.`;
+    }
+    return `No explicit word target. Write to the natural length of the form.`;
+  })();
+  const formatGuide = (() => {
+    const fmt = req.deliverableFormat;
+    if (!fmt) return '';
+    const lower = fmt.toLowerCase();
+    if (lower === 'literature review' || lower === 'systematic review') {
+      return `\n\nDELIVERABLE FORMAT — ${fmt}:
+- Structural template: brief Introduction → one section per source (Article 1, Article 2, …) each with sub-headings Introduction / Summary / Analysis / Conclusion → Final Synthesis comparing the sources → References.
+- Each per-source Analysis sub-section is the heaviest: it is where you EVALUATE the source against the assignment's criteria (audience fit, methodological strength, alignment with established frameworks, practical utility, limitations) using SPECIFIC details from that source — not generic comments about literature.
+- Cite each per-source section's claims back to that source's anchors. Cross-cite to other sources only in the Final Synthesis.`;
+    }
+    if (lower === 'lab report') {
+      return `\n\nDELIVERABLE FORMAT — lab report:
+- Structural template: Title → Abstract (optional) → Introduction → Method → Results → Discussion → Conclusion → References.
+- Method and Results are descriptive, low-citation; Introduction and Discussion carry the citations.`;
+    }
+    if (lower === 'policy memo' || lower === 'policy brief') {
+      return `\n\nDELIVERABLE FORMAT — ${fmt}:
+- Structural template: Title → BLUF (Bottom Line Up Front, 1–3 sentences) → Background → Analysis → Recommendations → References.
+- Lead with the recommendation; everything else justifies it.`;
+    }
+    if (lower === 'annotated bibliography') {
+      return `\n\nDELIVERABLE FORMAT — annotated bibliography:
+- One entry per source: full citation followed by a 100–200 word annotation (summary + evaluation + relevance to the project).
+- No body essay — the annotations ARE the deliverable.`;
+    }
+    return `\n\nDELIVERABLE FORMAT — ${fmt}: follow the standard structural conventions of this format.`;
+  })();
+  const frameworkGuide = req.framework
+    ? `\n\nFRAMEWORK / METHOD TO APPLY — ${req.framework}:
+- The user explicitly asked for this. APPLY it as the analytical lens that organises the draft. Don't write ABOUT the framework — USE it.
+- Concretely: each section's analysis should USE the framework's categories / criteria / steps to structure what you say about the evidence. If the framework has named domains/criteria/components, name them as you apply them.
+- ${guideAnchors.length > 0 ? 'Method instructions for this framework are in the GUIDANCE ANCHORS below — internalise them; never cite them.' : 'You may apply the framework from your own knowledge of it. Stay faithful to its standard form.'}`
+    : '';
+  const guidanceNote =
+    guideAnchors.length > 0
+      ? `\n\nThis session has ${guideAnchors.length} GUIDANCE-role anchor${guideAnchors.length === 1 ? '' : 's'}. They are method/framework material — read them, internalise the instructions, and write accordingly. NEVER cite them inline. NEVER include them in the References list. They are HOW you write, not WHAT you cite.`
+      : '';
 
   return `[HARD RULES — non-negotiable. Violating any of these is a shipping failure.]
 
-1. **CITE YOUR SOURCES.** The anchor log below is the session's evidence base. Every factual claim, specific number, named figure, technical definition, contested position, or historical fact in your draft MUST carry an inline Harvard citation drawn from the anchor log. A draft with ZERO citations is a hard failure — the whole point of the Deep Plan session was to gather these anchors. If you find yourself writing a factual sentence without a citation, either add one or remove the sentence.
+1. **CITE YOUR SOURCES.** The reference-role anchor log below is the session's evidence base. Every factual claim, specific number, named figure, technical definition, contested position, or historical fact in your draft MUST carry an inline Harvard citation drawn from a REFERENCE-role anchor. A draft with ZERO citations is a hard failure. Guidance-role anchors are NEVER cited.
 
-2. **FORMAT — in-text citation:** \`([Author, Year](slug.md#anchor-id))\`. The whole parenthesised chunk — including "Author, Year" — is a single markdown link whose href carries the \`#anchor-id\`. Reader sees "(Author, Year)"; hover reveals the verbatim anchor passage. Examples: \`([Sen, 1970](sen-liberal-paradox.md#impossibility-theorem))\`, \`([Stanford Encyclopedia, 2018](pareto-efficiency.md#three-conditions))\`. When you genuinely can't infer a year from the source (no date in the summary or URL), use just the author/source name: \`([Sen](sen-liberal-paradox.md#x))\`. NEVER drop the \`#anchor-id\` fragment — it powers the hover preview that lets readers cross-check your paraphrase.
+2. **FORMAT — in-text citation:** \`([Author, Year](slug.md#anchor-id))\`. The whole parenthesised chunk is a single markdown link whose href carries the \`#anchor-id\`. Reader sees "(Author, Year)"; hover reveals the verbatim anchor passage. The exact "(Author, Year)" string to type is shown next to each reference anchor below — use it verbatim. NEVER drop the \`#anchor-id\` fragment.
 
-3. **CITATION DENSITY floor.** Roughly 1 citation per 150–200 words of body prose. For a 2,000-word essay that means ~10–15 inline citations minimum. Fewer than that means you're gliding past load-bearing claims without grounding them. Over-citation (every sentence cited) is also bad — consolidate when adjacent sentences lean on the same anchor — but ZERO is a failure mode we've seen and this prompt is here to stop it.
+3. **CITATION DENSITY floor.** Roughly 1 citation per 150–200 words of body prose. For a 2,000-word essay that means ~10–15 inline citations minimum. Fewer means you're gliding past load-bearing claims without grounding them.
 
-4. **ZERO em dashes (—) in the final draft.** If you feel the urge, use a period, comma, parentheses, or a colon instead. Em dashes are the strongest AI-prose tell. Do not use en dashes (–) as a substitute either.
+4. **ZERO em dashes (—) in the final draft.** Use a period, comma, parentheses, or colon instead. Em dashes are the strongest AI-prose tell. Don't substitute en dashes (–) either.
 
-5. **HONOUR THE WORD-COUNT RANGE** in the rubric. Going over or under by more than 10% is a failure.
+5. **HONOUR THE WORD-COUNT RANGE.** Going over or under by more than 10% is a failure. ${wordCountLine}
 
-6. **STRUCTURE WITH HEADINGS.** Every draft opens with a \`# Title\` H1 and breaks the body into \`## Section\` H2s that follow the vision's "Structure" section (when present) or derive from the form (3–6 H2s for a standard essay, 2–4 for a blog/op-ed, 5–8 for a report). Section titles tell the reader what the section ARGUES, not just what topic it covers. A wall of unbroken prose with no H2s is a shipping failure — full details in the "Structure + headings" block below.
+6. **STRUCTURE WITH HEADINGS.** Every draft opens with a \`# Title\` H1 and breaks the body into \`## Section\` H2s. Section titles tell the reader what the section ARGUES, not just what topic it covers. A wall of unbroken prose with no H2s is a shipping failure.
 
-You are Myst, writing the first full draft of "${docLabel}" from a completed Deep Plan session. You are an essayist with an evidence bundle. The VISION is the intellectual spine (thesis, POV, section intents). The ANCHOR LOG is the evidence pile. Your job: turn the vision into finished analytical prose, grounded by the anchors, paraphrased naturally in your own voice.
+7. **APPLY USER-STATED CONSTRAINTS.** If the rubric names a framework or deliverable format, you MUST apply it. Writing about it instead of using it is a hard failure.
 
-User's task: "${session.task}"
+8. **DEPTH OVER BREADTH.** Each cited claim gets UNPACKED with the source's specifics — actual numbers, mechanisms, named techniques, concrete examples — not collapsed into a one-sentence summary. See the depth examples below.
+
+You are Myst, writing the first full draft of "${docLabel}" from a completed Deep Plan session. You are an essayist with an evidence bundle. The VISION is the intellectual spine. The ANCHOR LOG is the evidence pile. Your job: turn the vision into finished analytical prose, grounded by the anchors, in the writer's voice.
+
+User's task: "${session.task}"${constraintsLine}
 
 RUBRIC (HARD constraints — the draft is judged against these):
-${requirementsBlock(session.requirements)}
+${requirementsBlock(session.requirements)}${formatGuide}${frameworkGuide}${guidanceNote}
 
 VISION — the intellectual spine. Follow its thesis, POV, and section intents. The vision itself has no citations; it tells you WHAT to write.
 
@@ -663,72 +782,71 @@ ${visionBlock(session.vision)}
 
 ${anchorCountLine}
 
-Each anchor below shows its type, source name, and the verbatim source text. Reference anchors with their full \`([SourceName](slug.md#anchor-id))\` link — the \`slug.md#anchor-id\` is the exact form the hover feature expects. Paraphrase the text naturally; do NOT copy verbatim unless the exact wording is genuinely load-bearing.
+Each REFERENCE anchor below shows the citation tag you should type — \`(Author, Year)\` or \`(SourceName)\` — and the slug fragment that goes in the markdown link href. Paraphrase the anchor text naturally; do NOT copy verbatim unless the exact wording is genuinely load-bearing.
 
 ${anchorLogBlock(anchors)}
 
 HOW TO WRITE THE DRAFT:
 
-1. **Vision is your spine.** Its section intents are your structure. Its POV is the voice. Its novel insights are what the piece ARGUES. Execute the vision.
-2. **Anchors are evidence you USE.** Before writing each paragraph, scan the anchor log for entries relevant to that paragraph's claim — every factual sentence in the paragraph should be traceable to one of those anchors, with an inline citation attached.
-3. **Aim to use most of the log.** If the log has 20 anchors, expect 15+ to appear in the draft at least once. Anchors that genuinely don't fit the vision can be skipped — but the default is "use it". Every unused anchor is evidence you gathered and then ignored.
-4. **Paraphrase naturally, don't transcribe.** Compress three source sentences into one of yours; lift the load-bearing phrase; drop the rest. Sentence-by-sentence rewording of an anchor reads mechanical.
-5. **Lead paragraphs with YOUR claim.** A paragraph's first sentence should almost never be a cited external claim — it should be your analytical move, with the evidence brought in to support it after.
-6. **Uncited prose IS allowed** — for connective tissue, your own reasoning, textbook-level common knowledge, or transitions. Uncited prose is EARNED when the claim is uncontested background.
+1. **Vision is your spine.** Its section intents are your structure. Its POV is the voice. Its novel insights are what the piece ARGUES.
+2. **Reference anchors are evidence you USE.** For every claim, scan the reference anchors for one that grounds it. The citation tag tells you literally what to type.
+3. **Guidance anchors shape HOW you write.** They are framework / method / style instructions. Internalise them; never cite them.
+4. **Aim to use most of the reference log.** If the log has 20 reference anchors, expect 15+ to appear at least once. Unused anchors are evidence you gathered and ignored.
+5. **Lead paragraphs with YOUR claim.** A paragraph's topic sentence is your analytical move; the evidence comes in to support it.
+6. **Unpack each cited claim with SPECIFICS.** When an anchor names a method, name the method. When it gives a number, give the number. When it specifies a mechanism, describe the mechanism. Generic restatement isn't analysis.
+
+Depth — what shallow vs deep looks like:
+- Shallow: "The article highlights advances in monitoring technology." (Reader learns nothing specific.)
+- Deep: "The article divides assessment methods into two categories: non-invasive approaches such as behavioural observation and underwater imaging, and invasive physiological markers like cortisol assays — flagging that chronic stress depresses growth, immunity, and survival." (Reader learns WHAT, HOW, and SO WHAT.)
+- Shallow: "Research suggests welfare programs are increasingly important."
+- Deep: "Collins (2023) traces the absence of a national assurance scheme in Australia against the spread of comparable frameworks in the EU, where rising welfare standards now function as a market-access requirement for export dairy."
+The deep version is two-to-three times longer per claim — and that's the point. Draft length comes from depth per claim, NOT from extra claims.
 
 Citation mechanics (strict):
-- In-text format: \`([Author, Year](slug.md#anchor-id))\`. The entire \`([...](...))\` is one markdown link. Visible text is "Author, Year"; the hidden href carries \`slug.md#anchor-id\` so hover works. **Infer "Author, Year" from the anchor's source name + any year visible in the source summary / URL / text.** Authors: surname only (e.g. "Sen", "Feldstein", "Arrow"). Institutional sources: short label ("Stanford Encyclopedia", "Richmond Fed", "OECD").
+- Use the citation tag printed next to each reference anchor — that's the visible text. Don't invent a different one.
 - Examples:
   - Inline: \`...the liberal paradox ([Sen, 1970](sen-1970.md#liberal-paradox)) shows that minimal liberalism and Pareto are incompatible.\`
-  - Institution: \`...Feldstein's defence of efficiency-first policy ([Richmond Fed, 2011](richmond-feldstein.md#defense)) remains the canonical case.\`
-  - Year unknown (source carries no date): \`([Sen](sen-liberal-paradox.md#x))\` — drop the comma and year rather than inventing one.
+  - Institution: \`...as the Federal Reserve documents ([Richmond Fed, 2011](richmond-feldstein.md#defense)).\`
 - Two sources on a sentence → two adjacent citations: \`([Smith, 2022](smith.md#a)) ([Jones, 2019](jones.md#b))\`.
-- Same source, adjacent sentences → cite ONCE at the natural anchor point (end of topic sentence, or end of synthesis sentence).
-- Never wrap citations in backticks; never emit numeric footnote markers; never write "Smith et al. (2022)" as inline prose (your parenthesised markdown link IS the citation).
+- Same source, adjacent sentences → cite ONCE at the natural anchor point.
+- Never wrap citations in backticks; never emit numeric footnote markers; never write "Smith et al. (2022)" as inline prose (the parenthesised markdown link IS the citation).
 
-Blockquote discipline: default zero. One or two max if a primary-source quotation genuinely carries unique rhetorical weight.
+Blockquote discipline: default zero. One or two max if a primary-source quotation carries unique rhetorical weight.
 
 Voice:
-- Transitions should DO WORK — reframe, pivot, raise stakes. "The historical context matters" is dead weight; name what it matters FOR. "The criticism cuts deeper" is filler; name the specific cut.
-- Avoid stock LLM tells: "These are not minor caveats", "The silence is not incidental", "It's worth noting", "The conclusion is straightforward", "This is significant because".
+- Transitions should DO WORK — reframe, pivot, raise stakes. "The historical context matters" is dead weight; name what it matters FOR.
+- Avoid stock LLM tells: "These are not minor caveats", "It's worth noting", "The conclusion is straightforward", "This is significant because".
 
 Counter-argument + conclusion:
 - Address the strongest objection to the thesis before rebutting or conceding. Name it specifically.
 - The conclusion engages every major thread the body developed, named specifically. No generic "supplementing with frameworks that engage..." lists.
 
 References section (required, end of draft) — HARVARD STYLE:
-- \`## References\` heading (sentence case, no variations).
-- List every unique slug actually cited in the body, once each. ONE bullet per source.
-- Harvard format, per entry:
-  \`- Author (Year) *Title*. Publisher or outlet. [[web](https://…)] [[source](slug.md)]\`
-  - **Author**: surname(s), full initial(s). "Sen, A." / "Smith, J. and Jones, K." Institutional source: full name — "Stanford Encyclopedia of Philosophy", "Federal Reserve Bank of Richmond".
-  - **(Year)**: in parentheses immediately after the author. If truly unknown, use \`(n.d.)\`.
-  - **Title** in italics. Preserve the original capitalisation from the source.
-  - **Publisher / outlet** if identifiable (journal name, news outlet, publisher, institution).
-  - **\`[[web](URL)]\`** — clickable link to the original website the source lives on. Take the URL from the anchor entry (the anchor list's "source URL" or, failing that, the URL visible in the anchor text / summary). Include this ONLY when you have a real URL; do not invent one.
-  - **\`[[source](slug.md)]\`** — ALWAYS the final element: the Myst-internal link to the source's wiki page, so the reference stays clickable inside the app even when the original URL is paywalled / dead / missing.
-- Both links go inside double square brackets so they render as distinct link-chip tails rather than dissolving into the prose. \`[web]\` first, \`[source]\` last.
+- \`## References\` heading (sentence case).
+- ONE bullet per UNIQUE slug you actually CITED INLINE in the body. NOT one per anchor (multiple anchors share a slug). NOT one per source in the wiki (don't list uncited sources). NOT one per guidance source (NEVER list guidance sources).
+- Harvard format per entry:
+  \`- Author (Year) *Title*. Publisher or outlet. doi:10.xxxx/xxxx [[web](https://…)] [[source](slug.md)]\`
+  - **Author**: surname(s) with initial(s) when known ("Sen, A.", "Smith, J. and Jones, K."). Institutional: full name. Use the author shown in the citation tag.
+  - **(Year)**: integer year when shown in the citation tag. \`(n.d.)\` only as a last resort.
+  - **Title** in italics, original capitalisation. The reference anchors carry titles when extracted at ingest.
+  - **Publisher / outlet** when identifiable (journal name, news outlet, institution).
+  - **\`doi:...\`** when present — bare DOI prefix, no URL.
+  - **\`[[web](URL)]\`** — clickable link to the original. Use the source URL shown in anchor entries. Omit if you don't have one.
+  - **\`[[source](slug.md)]\`** — always the final element: Myst-internal link.
 - Examples:
   - \`- Sen, A. (1970) *The Impossibility of a Paretian Liberal*. Journal of Political Economy. [[web](https://www.jstor.org/stable/1829989)] [[source](sen-1970.md)]\`
+  - \`- Barreto, M. O., Planellas, S. R., Yang, Y., Phillips, C., & Descovich, K. (2021) *Emerging indicators of fish welfare in aquaculture*. Reviews in Aquaculture. doi:10.1111/raq.12601 [[source](barreto-2021.md)]\`
   - \`- Stanford Encyclopedia of Philosophy (2018) *Pareto Efficiency*. [[web](https://plato.stanford.edu/entries/pareto/)] [[source](pareto-efficiency.md)]\`
-  - \`- Richmond Fed (2011) *Efficient Rent Seeking*. Federal Reserve Bank of Richmond. [[source](richmond-feldstein.md)]\` *(no URL available; web chip omitted)*
-- Alphabetise by author surname (or institution name when author-less). One bullet per source. Do NOT list sources you didn't cite in the body. Do NOT duplicate.
-- Infer metadata from the anchor log entries — each anchor shows its source name + URL, and many anchor texts reveal year / publisher. If a field is genuinely unrecoverable, omit it rather than invent. The ONE required element you must never skip is the trailing \`[[source](slug.md)]\` chip.
+- Alphabetise by author surname (or institution name when author-less). Do NOT duplicate. Do NOT include any guidance-role source.
 
-Structure + headings (mandatory — draft gets rejected without them):
-- **Open with a \`# Title\` H1.** Never ship a draft with no title line. Pick a title that names the piece's actual angle, not a generic restatement of the task.
-- **Use H2 section headings (\`## Section title\`) to break the body into its thread arc.** Derive the H2s from the vision's section-arc line (the brief intents it lists: "open with X", "pivot to Y", "land on Z") + the form — you pick the actual H2 titles, not the vision.
-  - **Essay (1500–2500 words)**: 3–6 H2 sections. Never one continuous flow.
-  - **Blog post (800–1500 words)**: 2–4 H2 sections.
-  - **Op-ed (800–1500 words)**: usually 2–4 H2s, sometimes 1 if the argument is tightly linear.
-  - **Report (2500+ words)**: 5–8 H2 sections, often with H3 sub-sections.
-- Section titles do the work — they should tell a reader what the section argues, not just what topic it covers. "The decomposition that gets cited" beats "Background".
-- **References is its own \`## References\` H2 at the end.** Not in the body flow; always the final section.
-- H3+ sub-headings are allowed for long/structured pieces (reports especially) but optional for essays.
+Structure + headings (mandatory):
+- **Open with a \`# Title\` H1.** Pick a title that names the piece's actual angle, not a restatement of the task.
+- **Use H2 section headings (\`## Section title\`) to break the body.** Derive the H2s from the vision's section-arc + the deliverable format above. The deliverable-format guide names structural sections when relevant — use those H2 names; otherwise pick H2s that argue rather than label.
+- **References is its own \`## References\` H2 at the end.** Always the final section.
 
 Form + output rules:
-- Hit the rubric — length, form, audience.
-- No preamble, no "Here is your draft:", no meta-commentary. Start with the H1 title line and write straight through.
+- Hit the rubric — length, form, audience, deliverable format, framework.
+- No preamble, no "Here is your draft:", no meta-commentary. Start with the H1 title line.
 - Use proper markdown: \`#\` title, \`## Section\` H2s, \`**bold**\`, \`*italic*\`, blank lines between paragraphs.
 
 Output: the complete markdown draft, nothing else.

--- a/src/main/features/deepPlan/prompts.ts
+++ b/src/main/features/deepPlan/prompts.ts
@@ -11,10 +11,10 @@ import type {
   SourceMeta,
 } from '@shared/types';
 import {
-  DEEP_PLAN_MAX_QUESTIONS_PER_ROUND,
-  DEEP_PLAN_MAX_SEARCHES_PER_ROUND,
   DEEP_PLAN_MAX_TOTAL_SEARCHES,
   DEEP_PLAN_SOFT_ROUND_LIMIT_PER_PHASE,
+  DEEP_PLAN_TARGET_QUESTIONS_PER_ROUND,
+  DEEP_PLAN_TARGET_SEARCHES_PER_ROUND,
 } from '@shared/types';
 import { PROSE_STYLE } from '../../writing';
 import { PREFERRED_SOURCE_HINT } from '../research/credibility';
@@ -265,7 +265,7 @@ function sourcesBlock(sources: SourceMeta[]): string {
 
 function searchBudgetBlock(session: DeepPlanSession): string {
   const remaining = Math.max(0, DEEP_PLAN_MAX_TOTAL_SEARCHES - session.searchesUsed);
-  return `Search budget: ${session.searchesUsed}/${DEEP_PLAN_MAX_TOTAL_SEARCHES} used, ${remaining} remaining. Per-round panel cap: ${DEEP_PLAN_MAX_SEARCHES_PER_ROUND}. Searches are welcome — especially early, when the plan is sparse and one grounding source can sharpen a whole section. Don't burn every round on searches, but don't go silent either: when a specific plan claim would land harder with a primary source the wiki doesn't have yet, propose the query.
+  return `Search budget: ${session.searchesUsed}/${DEEP_PLAN_MAX_TOTAL_SEARCHES} used, ${remaining} remaining. Search is USER-GATED — when you want a specific source the wiki lacks, attach a \`delegableQuery\` to a user-prompt phrased as a question ("Want me to look up X?"). The query fires only if the writer delegates. Never auto-search; never propose a search without a user-prompt to host it.
 
 ${PREFERRED_SOURCE_HINT}`;
 }
@@ -381,19 +381,60 @@ function panelContextBlock(ctx: PanelContext): string {
     chatNotesBlock(chatNotes),
     '',
     priorFindingsDigest
-      ? `Prior-round panel output digest (do NOT repeat these — raise NEW proposals):\n${priorFindingsDigest}`
+      ? `Prior-round Chair summaries (don't re-raise concerns the Chair already addressed; DO raise new ones, including new searches when this round's specific sub-claims need grounding):\n${priorFindingsDigest}`
       : '(no prior rounds)',
   ].join('\n');
+}
+
+/**
+ * How loud to be with user-prompts per mode. Probe modes (idea-exploration,
+ * argumentative-essay) actively want the panel surfacing concerns to the
+ * user — the user's hand on the wheel is the whole point. Quiet modes
+ * (literature-review, analytical-report, comparative-analysis) lean on
+ * the sources; panelists only ask when something genuinely forks.
+ */
+function panelVerbosityForMode(mode: DeepPlanMode): { cadence: string } {
+  switch (mode) {
+    case 'idea-exploration':
+    case 'argumentative-essay':
+      return {
+        cadence:
+          'PROBE. The writer is the centre of gravity — your role is to surface the things they should weigh in on. Typical: 1 user-prompt per panelist when you have a real concern, question, or idea worth their attention. Scale up to 2 for genuinely deep / ambiguous topics where the writer would benefit from layered probing. Stay at 0 only when your lens is already addressed by the existing vision + answers. A vague "have you considered…" is worse than going silent — but a SHARP question with a clear fork is the whole point of your role.',
+      };
+    case 'literature-review':
+    case 'analytical-report':
+    case 'comparative-analysis':
+    default:
+      return {
+        cadence:
+          'BE QUIET. The deliverable leans on sources, not the writer\'s preferences. Emit a user-prompt only when something genuinely forks (ambiguous criterion, missing source the writer should choose). Most rounds, emit []. Going silent is the right move.',
+      };
+  }
 }
 
 export function panelistPrompt(role: PanelRole, ctx: PanelContext): string {
   const persona = ROLE_PERSONAS[role];
   const canSearch = ctx.remainingSearchBudget > 0;
+  const verbosity = panelVerbosityForMode(ctx.session.mode);
   const searchClause = canSearch
-    ? `- \`needsResearch\`: up to ${DEEP_PLAN_MAX_SEARCHES_PER_ROUND} queries when a specific plan claim would land harder with a source the wiki lacks. Any role may request — not just Evidence. Early ideation rounds benefit most: one or two seed queries on the core concept can reshape the whole plan.`
-    : `- \`needsResearch\`: emit []. The session search budget is exhausted — work with the plan and wiki you already have.`;
+    ? `Two search lanes — pick by ASKING WHO BENEFITS:
+- \`needsResearch\` (AUTO-FIRES, default lane): when the LITERATURE EXISTS and would help, the writer's answer doesn't change whether we should fetch it. Examples: "constrained decoding vs reward shaping in RLHF", "case studies of Pareto efficiency in welfare policy", "primary source for the Sen 1970 theorem". The writer can't add what's missing — search will.
+- \`userPrompts[].delegableQuery\` (USER-GATED, narrower): when the search depends on the WRITER'S CHOICE — mutually exclusive directions where they need to pick first. If the writer's answer doesn't change which search you'd run, it's auto-fire (\`needsResearch\`), not delegable.
 
-  return `You are ONE voice on a vision-steering panel. You do NOT talk to the writer. You do NOT curate anchors — anchor extraction happens deterministically at source-ingest time, and every extracted anchor flows to the drafter automatically. Your job is narrow: read the vision, flag what it's missing, and propose research queries when the wiki's coverage is thin.
+**YOUR per-panelist quota is small.** YOU panelists run in parallel; the round-level target is ~${DEEP_PLAN_TARGET_SEARCHES_PER_ROUND} search per round across the WHOLE panel (scaling to 2–3 for novel / unfamiliar topics). So your individual contribution is:
+- USUALLY 0. Most panelists emit \`needsResearch: []\` each round. Going silent here is correct, not lazy.
+- ONLY 1 if YOUR specific lens spots a CLEARLY UNCOVERED, LOAD-BEARING gap that no other lens is more entitled to flag. Pick the SHARPEST gap from your role's POV; don't fire on a "nice to have".
+- Two only if the topic is genuinely novel AND you're the most-relevant lens for both gaps. Rare.
+
+**Search is per-claim, not per-session** — do NOT suppress because the wiki has sources from earlier rounds. Coverage is judged PER SUB-CLAIM. A wiki of 8 sources isn't "enough" if this round's specific concern isn't covered. Re-evaluate from scratch each round. But: also don't fire just because we haven't searched yet this round — fire only when YOUR lens has a real, sharp gap.
+
+Default to \`needsResearch\` when the literature is the bottleneck. Default to \`userPrompts.delegableQuery\` only when the writer's preference picks the search direction. Session budget: ${DEEP_PLAN_MAX_TOTAL_SEARCHES} total.`
+    : `The session search budget is exhausted — emit \`needsResearch: []\` and do NOT attach \`delegableQuery\` to any user-prompt. Work with the wiki and vision you already have.`;
+
+  return `You are ONE voice on a vision-steering panel. You do NOT write the draft. You do NOT curate anchors — extraction is deterministic at ingest time. Your three outputs each round:
+1. **visionNotes** — private synthesis input the Chair reads. What's missing or off about the vision through your lens.
+2. **needsResearch** — auto-firing searches when the wiki has obvious coverage gaps on critical material. Use sparingly.
+3. **userPrompts** — concerns / questions / clarifications / ideas you want PUT IN FRONT OF THE WRITER. The Chair selects the sharpest few and surfaces them. Optionally carry a \`delegableQuery\` (user-gated search).
 
 Your role:
 ${persona}
@@ -402,26 +443,45 @@ Context:
 ${panelContextBlock(ctx)}
 
 How to think about your job:
-The vision above is what the writer + Chair have decided this piece is ABOUT — the thesis, POV, section intents, novel angles. Through your persona's lens, look for:
-1. Gaps in the vision itself — thesis weaknesses, missing counter-arguments, section intents that don't yet have a clear POV.
-2. Coverage gaps in the wiki — claims the piece will need to make that the current sources can't ground. These become \`needsResearch\` queries.
+Through your persona's lens, look for:
+1. Gaps in the vision the writer should know about and weigh in on.
+2. Choices only the writer can make (framing forks, scope decisions, taste calls).
+3. Wiki anchors that CREATE TENSION with the writer's vision — "X (already in your wiki) says Y, does that change your stance?" is a strong source-driven user-prompt. Use existing anchors as conversation hooks, not just vision sources.
+4. Coverage gaps in the wiki — pick the lane:
+   - Confident "we need this regardless" → \`needsResearch\` (auto-fires).
+   - "Want me to look this up?" / depends on user input → \`userPrompts[]\` with \`delegableQuery\`.
 
-You are NOT trying to cover the topic comprehensively. One crisp vision observation + one or two research queries (when needed) is a strong round from one role. Small and sharp beats broad and shallow.
+Mode cadence — ${ctx.session.mode}:
+${verbosity.cadence}
+
+User-prompts beat going silent only when you have a SPECIFIC concern, question, clarification request, or idea that the writer's answer would meaningfully change. Vague "have you thought about this?" filler is worse than emitting [].
 
 Output ONLY a JSON object of this exact shape — no prose, no markdown fences, no commentary:
 
 {
-  "visionNotes": "≤ 2 sentences. What's missing or off about the vision, through your role's lens. Empty string when you have nothing to add.",
+  "visionNotes": "≤ 2 sentences. Private input for the Chair. What's missing or off about the vision, through your role's lens. Empty string when you have nothing to add.",
   "needsResearch": [
-    {"query": "3–5 plain lowercase terms, no site: filters", "rationale": "what anchor type (statistic/definition/claim/finding/quote) this query should yield, and what claim in the vision it unblocks"}
+    {"query": "3–5 plain lowercase terms, no site: filters", "rationale": "what the search should yield + which vision claim it grounds"}
+  ],
+  "userPrompts": [
+    {
+      "kind": "concern" | "question" | "clarification" | "idea",
+      "prompt": "the prompt as the WRITER will read it — one clear sentence ideally",
+      "rationale": "one line — why your role is raising this",
+      "delegableQuery": "OPTIONAL. A search query (3–5 plain terms, no site: filters) that fires iff the writer delegates. Omit when no search is involved."
+    }
   ]
 }
 
 Rules:
-- \`visionNotes\`: one crisp observation through your role's lens. Not a list of five vague suggestions. If the vision is solid from your lens, emit "".
-- \`needsResearch\`: queries must target NEW ground. If the wiki already has 2+ sources on the same concept at similar depth, do NOT request a third — pivot to a primary-source author, a landmark paper, or an adjacent angle instead.
+- All three lanes are independent — silent on any combination is fine.
+- Volume scales with topic depth + ambiguity (see your mode cadence above). \`needsResearch\` is your default grounding lane; \`userPrompts\` are the rarer probing lane.
+- \`needsResearch\` queries must target NEW ground. If the wiki has 2+ sources on the same concept, do NOT request a third — pivot or drop.
+- \`kind\` (userPrompts): "concern" = something off; "question" = writer's input needed; "clarification" = something ambiguous; "idea" = a direction worth exploring.
+- \`prompt\`: write it as if the writer reads it directly. First-person. No "the panel thinks…" wrapper.
+- \`rationale\`: one line of context for the Chair, NOT shown to the user verbatim.
 ${searchClause}
-- If you have nothing useful this round, output {"visionNotes": "", "needsResearch": []}. Going silent is the right move when your lens is already addressed.`;
+- Empty is a strong round when there's nothing to add — output {"visionNotes": "", "needsResearch": [], "userPrompts": []}.`;
 }
 
 /* ────────────────────────── Chair (strong-model) ────────────────────────── */
@@ -438,16 +498,28 @@ function findingsBlock(panelOutputs: PanelOutput[]): string {
   return panelOutputs
     .map((p) => {
       const header = `### ${p.role.toUpperCase()}`;
-      const silent = !p.visionNotes.trim() && p.needsResearch.length === 0;
+      const silent =
+        !p.visionNotes.trim() && p.userPrompts.length === 0 && p.needsResearch.length === 0;
       if (silent) return `${header}\n(no notes this round)`;
       const vision = p.visionNotes.trim() ? `Vision note: ${p.visionNotes.trim()}` : '';
-      const research =
+      const autoSearch =
         p.needsResearch.length > 0
-          ? `${vision ? '\n' : ''}Research requested:\n${p.needsResearch
+          ? `${vision ? '\n' : ''}Auto-search dispatched:\n${p.needsResearch
               .map((r) => `  - "${r.query}" — ${r.rationale}`)
               .join('\n')}`
           : '';
-      return `${header}\n${vision}${research}`.trim();
+      const prompts =
+        p.userPrompts.length > 0
+          ? `${vision || autoSearch ? '\n' : ''}User-prompts proposed:\n${p.userPrompts
+              .map((u) => {
+                const search = u.delegableQuery
+                  ? ` [search-if-delegated: "${u.delegableQuery}"]`
+                  : '';
+                return `  - [${u.kind}] "${u.prompt}" — ${u.rationale}${search}`;
+              })
+              .join('\n')}`
+          : '';
+      return `${header}\n${vision}${autoSearch}${prompts}`.trim();
     })
     .join('\n\n');
 }
@@ -579,7 +651,7 @@ export function chairPrompt(args: ChairPromptArgs): string {
 Your job each round is narrow:
 1. **Steer** — reply to the user in a short \`summary\`. Conversational, first-person, specific to what actually moved.
 2. **Sharpen the VISION** — only when this round's panel vision-notes + chat-notes + new sources genuinely move the thesis, POV, or section intents. Most rounds, emit \`visionUpdate: null\`.
-3. **Probe the user** — ask 0–${DEEP_PLAN_MAX_QUESTIONS_PER_ROUND} targeted questions only when a genuine judgment call needs them.
+3. **Probe the user** — ask targeted questions only when a genuine judgment call needs them. Aim for ~${DEEP_PLAN_TARGET_QUESTIONS_PER_ROUND} per round on average; push higher when the topic is ambiguous or the writer is exploring, lower (often 0) when the topic is well-defined.
 4. **Update the rubric** — \`requirementsPatch\` when the user just answered a hard-requirement question.
 
 Phase intent:
@@ -615,10 +687,12 @@ ${priorSummaries ? `Prior-round Chair summaries (do NOT repeat these — move th
     {
       "id": "q1",
       "type": "choice" | "multi" | "open" | "confirm",
-      "prompt": "the question as a single clear sentence",
+      "prompt": "the question as a single clear sentence — the user reads this verbatim",
       "choices": [{"id": "short-id", "label": "the option as the user sees it", "recommended": true}],
       "allowCustom": false,
-      "rationale": "optional one-line why this matters"
+      "rationale": "optional one-line why this matters",
+      "proposedBy": "explorer | scoper | stakes | architect | evidence | steelman | skeptic | adversary | editor | audience | finaliser | chair",
+      "delegableQuery": "OPTIONAL search query to fire iff the user picks the 'research this' answer. Carry forward when surfacing a panelist's user-prompt that had one; omit otherwise."
     }
   ],
   "phaseAdvance": true | false,
@@ -652,9 +726,13 @@ Pre-emit micro-check (run BEFORE finalising visionUpdate):
 - For each LOAD-BEARING term in the vision (proper noun, coined phrase, named framework), is it defined inline OR grounded in a specific anchor? If neither, drop the term or replace with the concrete description it stands for. A thesis that hinges on an undefined coined term is a vibes thesis.
 - For each "Novel insight", could the drafter unpack it into 200 words of specific prose without making things up? If not, the insight is a wishbone — sharpen or drop.
 
-Question rules:
-- **FIRST PRIORITY — missing hard requirements.** If the rubric above lists any field as "(not specified)" (especially word count), ask about them THIS ROUND. Use \`choice\` with 3–4 reasonable defaults and mark one \`recommended\`. Example for word count: {1000–1500, 1500–2500, 2500–4000, custom with \`allowCustom: true\`}.
-- At most ${DEEP_PLAN_MAX_QUESTIONS_PER_ROUND} questions. Once requirements are complete, the user has delegated — ASK ONLY when a judgment call genuinely needs them (a thesis fork, a scope trade-off, a framing they haven't signalled). Empty array is often the right answer.
+Question rules — SCALE BY TOPIC AMBIGUITY:
+- **Aim for ~${DEEP_PLAN_TARGET_QUESTIONS_PER_ROUND} questions per round.** Push UP to 3–4 for genuinely deep / abstract / underspecified topics where the writer is still discovering what they mean. Drop to 0–1 only when the topic is well-defined and the writer's hand is firm.
+- **Surfacing IS the value.** If the panel raised 4–6 substantive concerns / questions / ideas, surfacing only 1 is a failure mode — you're hiding the panel's work. Most rounds, surface 2–3 of the strongest panel prompts. Cut only the ones that are genuinely weak (vague filler, duplicates, anything trivially answerable from the vision).
+- **FIRST PRIORITY — missing hard requirements.** If the rubric lists a field as "(not specified)" (especially word count), ask THIS ROUND. Use \`choice\` with 3–4 reasonable defaults, mark one \`recommended\`. Set \`proposedBy: "chair"\`.
+- **SECOND PRIORITY — surface panelist user-prompts.** Sort the panel's prompts by how much the writer's answer would move the next round, take the top 2–3. Good prompts: thesis branches, scope decisions, framing calls, sharp "have you considered…" with a real concern. Weak prompts to cut: vague clarifications, broad "what do you think?", duplicates.
+- When surfacing a panelist prompt: set \`proposedBy\` to that panelist's role (e.g. \`"skeptic"\`). You may rephrase \`prompt\` for clarity, preserve intent. Carry forward \`delegableQuery\` when present — that's the "research this" option.
+- Don't surface the same concern twice — merge duplicates, pick the strongest framing.
 - Prefer \`choice\` > \`confirm\` > \`multi\` > \`open\`. Mark ONE choice \`recommended\` when there's a defensible default. Set \`allowCustom: true\` when the options don't exhaust the space.
 - **NEVER ask a "ready to advance to the next phase?" or "shall we move on?" question via the question card.** The UI has its own phase-advance CTA the user can hit whenever they want. If you think the phase is ready to close, set \`phaseAdvance: true\` AND mention it conversationally in your \`summary\` (e.g. "I think we're ready for planning — hit Continue when you are, or keep chatting if there's more to work through."). Never split that decision across a question card — you end up with a phantom answer recorded in the transcript while the phase doesn't actually advance.
 

--- a/src/main/features/deepPlan/state.ts
+++ b/src/main/features/deepPlan/state.ts
@@ -40,6 +40,8 @@ function emptyRequirements(): PlanRequirements {
     form: null,
     audience: null,
     styleNotes: null,
+    framework: null,
+    deliverableFormat: null,
   };
 }
 
@@ -66,6 +68,35 @@ export function extractRequirements(task: string): PlanRequirements {
       const n = Number(singleMatch[1]);
       out.wordCountMin = n;
       out.wordCountMax = n;
+    }
+  }
+
+  // Deliverable format — specific format names take priority over generic
+  // forms below. These are the names that imply structural conventions
+  // (a literature review wants Article 1 / Article 2 sections, a lab
+  // report wants method/results/discussion, etc.). Match the LONGEST first
+  // so "literature review" beats the bare "review".
+  const deliverableFormats = [
+    'literature review',
+    'lab report',
+    'case study',
+    'policy memo',
+    'policy brief',
+    'systematic review',
+    'meta-analysis',
+    'annotated bibliography',
+    'thesis chapter',
+    'dissertation chapter',
+    'op-ed',
+    'whitepaper',
+    'white paper',
+    'research proposal',
+    'grant proposal',
+  ];
+  for (const f of deliverableFormats) {
+    if (lower.includes(f)) {
+      out.deliverableFormat = f;
+      break;
     }
   }
 
@@ -97,6 +128,34 @@ export function extractRequirements(task: string): PlanRequirements {
     /\bfor\s+(?:a\s+|an\s+|the\s+)?([a-zA-Z][a-zA-Z\s-]{3,40}?)\s+(?:audience|readers?|community|crowd)\b/i,
   );
   if (audienceMatch) out.audience = audienceMatch[1]!.trim();
+
+  // Framework / method / theoretical lens — patterns like:
+  //   "use the Five Domains framework"
+  //   "apply the CRAAP test"
+  //   "via the STAR method"
+  //   "through the lens of intersectionality"
+  // We capture the named thing rather than a freeform phrase, so the Chair
+  // and drafter can echo it verbatim. Phrasing patterns are deliberately
+  // narrow — false positives here would inject a fake framework into the
+  // prompt every round.
+  const frameworkPatterns: RegExp[] = [
+    /\b(?:using|use|apply(?:ing)?|via|through|with|following)\s+(?:the\s+)?([A-Z][A-Za-z0-9'’\-]+(?:\s+[A-Za-z0-9'’\-]+){0,4})\s+(?:framework|model|method|approach|theory|test|lens|paradigm|rubric|criteria)\b/,
+    /\b([A-Z][A-Za-z0-9'’\-]+(?:\s+[A-Za-z0-9'’\-]+){0,4})\s+(?:framework|model|method|approach|theory|test|lens|paradigm|rubric|criteria)\b/,
+    /\bthrough the lens of\s+([A-Za-z][A-Za-z0-9'’\-\s]{2,40})\b/i,
+  ];
+  for (const re of frameworkPatterns) {
+    const m = task.match(re);
+    if (m && m[1]) {
+      const candidate = m[1].trim();
+      // Reject candidates that are pure stopword phrases (the regex can
+      // sometimes grab "the same" or "this generic" when the user prose
+      // is loose).
+      if (!/^(the|this|that|same|generic|standard|usual|simple)\b/i.test(candidate)) {
+        out.framework = candidate;
+        break;
+      }
+    }
+  }
 
   return out;
 }

--- a/src/main/features/deepPlan/state.ts
+++ b/src/main/features/deepPlan/state.ts
@@ -1,12 +1,13 @@
 import { promises as fs } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import type {
+  DeepPlanMode,
   DeepPlanPhase,
   DeepPlanSession,
   DeepPlanStatus,
   PlanRequirements,
 } from '@shared/types';
-import { DEEP_PLAN_PHASE_ORDER } from '@shared/types';
+import { DEEP_PLAN_MODES, DEEP_PLAN_PHASE_ORDER } from '@shared/types';
 import { projectPath, projectRoot, ensureDir, log } from '../../platform';
 
 /**
@@ -215,6 +216,10 @@ function backfillLegacy(parsed: Record<string, unknown>): void {
   if (!parsed.phase) parsed.phase = 'ideation';
   if (!Array.isArray(parsed.pendingQuestions)) parsed.pendingQuestions = [];
   if (!Array.isArray(parsed.pendingChatNotes)) parsed.pendingChatNotes = [];
+  if (!Array.isArray(parsed.seenAnchorIds)) parsed.seenAnchorIds = [];
+  if (typeof parsed.mode !== 'string' || !DEEP_PLAN_MODES.includes(parsed.mode as DeepPlanMode)) {
+    parsed.mode = 'argumentative-essay';
+  }
   // Migration path: we've been through two anchor architectures. Legacy
   // sessions may have `plan` (pre-vision architecture) or `anchorLog`
   // (panel-curated era). Both are dropped silently — the new anchor
@@ -281,7 +286,10 @@ export async function deleteSession(): Promise<void> {
   }
 }
 
-export async function createSession(task: string): Promise<DeepPlanSession> {
+export async function createSession(
+  task: string,
+  mode: DeepPlanMode = 'argumentative-essay',
+): Promise<DeepPlanSession> {
   const root = projectRoot();
   const now = new Date().toISOString();
   const trimmed = task.trim();
@@ -290,11 +298,13 @@ export async function createSession(task: string): Promise<DeepPlanSession> {
     projectPath: root,
     phase: 'ideation',
     task: trimmed,
+    mode,
     requirements: extractRequirements(trimmed),
     vision: '',
     messages: [],
     pendingQuestions: [],
     pendingChatNotes: [],
+    seenAnchorIds: [],
     roundsPerPhase: emptyRoundsPerPhase(),
     searchesUsed: 0,
     tokensUsedK: 0,
@@ -306,6 +316,7 @@ export async function createSession(task: string): Promise<DeepPlanSession> {
   await writeSession(session);
   log('deep-plan', 'session.created', {
     task: trimmed.slice(0, 120),
+    mode,
     requirements: session.requirements,
   });
   return session;

--- a/src/main/features/sources/digest.ts
+++ b/src/main/features/sources/digest.ts
@@ -1,4 +1,4 @@
-import type { SourceMeta } from '@shared/types';
+import type { SourceBibliographic, SourceMeta, SourceRole } from '@shared/types';
 import { completeText } from '../../llm';
 import { log, logError } from '../../platform';
 import { getSummaryModel } from '../settings';
@@ -35,6 +35,16 @@ export interface SourceDigest {
   anchors: SourceAnchor[];
   relatedSlugs: string[];
   /**
+   * Detected by the digest model from the source's content shape. `'guidance'`
+   * means the source is a method/framework/style guide that should INFORM
+   * how the drafter writes but never appear as a citation. `'reference'`
+   * (the overwhelming default) means the source is content to cite. When
+   * the digest can't tell, defaults to `'reference'`.
+   */
+  role: SourceRole;
+  /** Bibliographic metadata extracted from the source's title page / header / URL. */
+  bibliographic?: SourceBibliographic;
+  /**
    * True when the digest LLM call failed (missing key, network error,
    * invalid JSON) and we fell back to truncated raw text. Research
    * auto-ingest uses this to drop the source before persisting — a
@@ -57,6 +67,15 @@ const SYSTEM_PROMPT = `You process source material into a research wiki entry. G
   "name": "A short, descriptive title for this source (2-6 words)",
   "summary": "A detailed wiki-style summary of the source content. 2-4 paragraphs covering the key points, arguments, data, and conclusions. Write in third person. Be thorough — this summary replaces the original for research purposes. You may use markdown links to reference other sources if relevant, using the format [Source Name](slug.md).",
   "indexSummary": "One sentence (under 20 words) describing what this source covers, for quick scanning.",
+  "role": "reference | guidance",
+  "bibliographic": {
+    "author": "Surname only ('Sen') OR institutional name ('Stanford Encyclopedia of Philosophy'). Omit when the source has no identifiable author.",
+    "year": 2023,
+    "title": "Title in original capitalisation. Omit when the source has no clear title.",
+    "journal": "Journal / publisher / outlet when stated. e.g. 'Journal of Political Economy', 'Reviews in Aquaculture', 'Nuffield Australia'. Omit when not stated.",
+    "doi": "Bare DOI without https prefix, e.g. '10.1111/raq.12601'. Omit when no DOI.",
+    "url": "Canonical URL when present in the text (often after 'Source URL:' or near the title). Omit otherwise."
+  },
   "anchors": [
     {
       "type": "definition | claim | statistic | quote | finding",
@@ -68,6 +87,12 @@ const SYSTEM_PROMPT = `You process source material into a research wiki entry. G
   "relatedSlugs": ["other_slug", "another_slug"],
   "isNonContent": false
 }
+
+role — load-bearing for downstream drafting:
+- **reference** (default — use this unless you're sure): the source is content to cite. Research papers, articles, news pieces, reports, datasets, primary documents, books, blog posts that present an argument or evidence. Anything the writer might quote or paraphrase as evidence in the final piece.
+- **guidance**: the source is a method / framework / style guide / how-to / rubric / assignment brief / scoring criteria — material that should INFORM HOW the writer writes, but never appear as a citation in the final piece. Examples: "How to write a literature review", "CRAAP test handout", "Five Domains framework explainer", "APA citation guide", "assignment instructions PDF", "course rubric". When in doubt, default to reference — guidance is the rare case.
+
+bibliographic — extract what's actually visible in the source text. Look at the title page (papers), masthead (articles), footer (web pages), or "Source URL:" prefix at the top of the raw text. Do NOT invent fields. If a field isn't visible, OMIT IT (don't emit empty strings, nulls, or "n.d."). For raw web pages with no clear author, the publisher/outlet alone is fine. For institutional pages (university, government, NGO), use the institution as author.
 
 isNonContent: set to true ONLY when the source text doesn't contain real, citable content on the topic implied by its title — examples: 404 / "page not found" error pages, login walls, cookie-consent shells, empty navigation skeletons, anti-bot / captcha pages, paywall stubs with no abstract. When true, leave summary/indexSummary/anchors/relatedSlugs as minimal placeholders (the system will drop the source entirely, so it doesn't matter). Default to false — a thin but real summary still counts as content. This flag is load-bearing: a wrong true will silently delete the source; a wrong false pollutes the wiki with junk.
 
@@ -111,8 +136,53 @@ function fallbackDigest(rawText: string, hint: string): SourceDigest {
     indexSummary: `Source: ${hint}`,
     anchors: [],
     relatedSlugs: [],
+    role: 'reference',
     isFallback: true,
   };
+}
+
+/**
+ * Coerce the LLM's bibliographic JSON blob into our typed shape, tolerating
+ * the model emitting empty strings / nulls for fields it couldn't extract.
+ * Returns `undefined` when nothing usable came back so the meta file stays
+ * tidy instead of carrying a noise bibliographic stub.
+ */
+function sanitizeBibliographic(raw: unknown): SourceBibliographic | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Record<string, unknown>;
+  const out: SourceBibliographic = {};
+  const str = (v: unknown): string | undefined => {
+    if (typeof v !== 'string') return undefined;
+    const trimmed = v.trim();
+    if (!trimmed) return undefined;
+    if (trimmed.toLowerCase() === 'n.d.' || trimmed.toLowerCase() === 'unknown') return undefined;
+    return trimmed;
+  };
+  const author = str(r.author);
+  if (author) out.author = author;
+  const yearVal = r.year;
+  if (typeof yearVal === 'number' && yearVal >= 1500 && yearVal <= 2100) {
+    out.year = Math.floor(yearVal);
+  } else if (typeof yearVal === 'string') {
+    const m = yearVal.match(/(\d{4})/);
+    if (m) {
+      const y = Number(m[1]);
+      if (y >= 1500 && y <= 2100) out.year = y;
+    }
+  }
+  const title = str(r.title);
+  if (title) out.title = title;
+  const journal = str(r.journal);
+  if (journal) out.journal = journal;
+  const doi = str(r.doi);
+  if (doi) out.doi = doi.replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '');
+  const url = str(r.url);
+  if (url && /^https?:\/\//i.test(url)) out.url = url;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function sanitizeRole(raw: unknown): SourceRole {
+  return raw === 'guidance' ? 'guidance' : 'reference';
 }
 
 /**
@@ -201,6 +271,8 @@ export async function generateDigest(
       anchors?: unknown;
       relatedSlugs?: unknown;
       isNonContent?: unknown;
+      role?: unknown;
+      bibliographic?: unknown;
     };
     if (parsed.isNonContent === true) {
       // Summary model flagged this as a non-content page (404, login
@@ -221,14 +293,19 @@ export async function generateDigest(
       typeof parsed.summary === 'string' ? parsed.summary : rawText.slice(0, 500);
     const relatedSlugs = sanitizeRelatedSlugs(parsed.relatedSlugs, existingSources, name);
     const summary = appendRelatedSection(rawSummary, relatedSlugs, existingSources);
-    return {
+    const role = sanitizeRole(parsed.role);
+    const bibliographic = sanitizeBibliographic(parsed.bibliographic);
+    const digest: SourceDigest = {
       name,
       summary,
       indexSummary:
         typeof parsed.indexSummary === 'string' ? parsed.indexSummary : `Source: ${hint}`,
       anchors,
       relatedSlugs,
+      role,
     };
+    if (bibliographic) digest.bibliographic = bibliographic;
+    return digest;
   } catch (err) {
     // Fallback used to be silent — made user-visible "summaries" that were
     // just the first 500 chars of the raw text. Log the model id and a

--- a/src/main/features/sources/index.ts
+++ b/src/main/features/sources/index.ts
@@ -2,7 +2,13 @@ import { promises as fs } from 'node:fs';
 import { basename, extname } from 'node:path';
 import { dialog } from 'electron';
 import { IpcChannels } from '@shared/ipc-channels';
-import type { AnchorLogEntry, SourceAnchorSummary, SourceIndex, SourceMeta } from '@shared/types';
+import type {
+  AnchorLogEntry,
+  SourceAnchorSummary,
+  SourceIndex,
+  SourceMeta,
+  SourceRole,
+} from '@shared/types';
 import { projectPath, pathExists, broadcast } from '../../platform';
 import { updateWikiIndex, appendWikiLog } from '../wiki';
 import { extractText } from './extract';
@@ -155,7 +161,9 @@ async function saveSource(
     indexSummary: digest.indexSummary,
     sourcePath,
     anchors: anchorSummaries,
+    role: digest.role,
   };
+  if (digest.bibliographic) meta.bibliographic = digest.bibliographic;
   await fs.writeFile(
     projectPath('sources', `${slug}.meta.json`),
     JSON.stringify(meta, null, 2),
@@ -465,13 +473,31 @@ export async function listAllAnchors(): Promise<AnchorLogEntry[]> {
           type: a.type,
           text: a.text,
           keywords: a.keywords ?? [],
+          role: s.role ?? 'reference',
         };
         if (s.sourcePath) entry.sourceUrl = s.sourcePath;
+        if (s.bibliographic) entry.bibliographic = s.bibliographic;
         out.push(entry);
       }
     }),
   );
   return out;
+}
+
+/**
+ * Flip a source between `'reference'` and `'guidance'`. Persists to the
+ * meta file and broadcasts so the renderer refreshes. Used when the digest
+ * misclassified a source (e.g. tagged a method guide as `'reference'`),
+ * letting the user fix it without re-ingesting.
+ */
+export async function setSourceRole(slug: string, role: SourceRole): Promise<SourceMeta> {
+  const path = projectPath('sources', `${slug}.meta.json`);
+  const raw = await fs.readFile(path, 'utf-8');
+  const meta = JSON.parse(raw) as SourceMeta;
+  meta.role = role;
+  await fs.writeFile(path, JSON.stringify(meta, null, 2), 'utf-8');
+  broadcast(IpcChannels.Sources.Changed);
+  return meta;
 }
 
 export async function deleteSource(slug: string): Promise<void> {

--- a/src/main/ipc/deepPlan.ts
+++ b/src/main/ipc/deepPlan.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { IpcChannels } from '@shared/ipc-channels';
-import type { ChairAnswerMap } from '@shared/types';
+import type { ChairAnswerMap, DeepPlanMode } from '@shared/types';
+import { DEEP_PLAN_MODES } from '@shared/types';
 import {
   advancePhase,
   buildStatus,
@@ -17,11 +18,15 @@ import {
 export function registerDeepPlanIpc(): void {
   ipcMain.handle(IpcChannels.DeepPlan.Status, () => buildStatus());
 
-  ipcMain.handle(IpcChannels.DeepPlan.Start, async (_event, task: unknown) => {
+  ipcMain.handle(IpcChannels.DeepPlan.Start, async (_event, task: unknown, mode: unknown) => {
     if (typeof task !== 'string' || task.trim().length === 0) {
       throw new Error('Task description is required.');
     }
-    return startSession(task);
+    const safeMode: DeepPlanMode =
+      typeof mode === 'string' && DEEP_PLAN_MODES.includes(mode as DeepPlanMode)
+        ? (mode as DeepPlanMode)
+        : 'argumentative-essay';
+    return startSession(task, safeMode);
   });
 
   ipcMain.handle(IpcChannels.DeepPlan.SendMessage, async (_event, message: unknown) => {

--- a/src/main/ipc/sources.ts
+++ b/src/main/ipc/sources.ts
@@ -9,6 +9,7 @@ import {
   listSources,
   pickSourceFiles,
   readSource,
+  setSourceRole,
 } from '../features/sources';
 import { readAnchor } from '../features/sources/lookup';
 
@@ -60,5 +61,14 @@ export function registerSourcesIpc(): void {
       throw new Error('Source slug must be a non-empty string.');
     }
     await deleteSource(slug.trim());
+  });
+  ipcMain.handle(IpcChannels.Sources.SetRole, async (_event, slug: unknown, role: unknown) => {
+    if (typeof slug !== 'string' || slug.trim().length === 0) {
+      throw new Error('Source slug must be a non-empty string.');
+    }
+    if (role !== 'reference' && role !== 'guidance') {
+      throw new Error('Role must be "reference" or "guidance".');
+    }
+    return setSourceRole(slug.trim(), role);
   });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -177,7 +177,7 @@ const api: MystApi = {
   },
   deepPlan: {
     status: () => ipcRenderer.invoke(IpcChannels.DeepPlan.Status),
-    start: (task) => ipcRenderer.invoke(IpcChannels.DeepPlan.Start, task),
+    start: (task, mode) => ipcRenderer.invoke(IpcChannels.DeepPlan.Start, task, mode),
     sendMessage: (message) => ipcRenderer.invoke(IpcChannels.DeepPlan.SendMessage, message),
     chat: (message) => ipcRenderer.invoke(IpcChannels.DeepPlan.Chat, message),
     runPanel: () => ipcRenderer.invoke(IpcChannels.DeepPlan.RunPanel),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -124,6 +124,7 @@ const api: MystApi = {
     lookupAnchor: (slug, anchorId) =>
       ipcRenderer.invoke(IpcChannels.Sources.LookupAnchor, slug, anchorId),
     delete: (slug) => ipcRenderer.invoke(IpcChannels.Sources.Delete, slug),
+    setRole: (slug, role) => ipcRenderer.invoke(IpcChannels.Sources.SetRole, slug, role),
     onChanged: (callback) => {
       const handler = (): void => {
         callback();

--- a/src/renderer/src/components/DeepPlanMode.tsx
+++ b/src/renderer/src/components/DeepPlanMode.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { USE_OPENMYST } from '@shared/flags';
+import type { DeepPlanMode } from '@shared/types';
+import { DEEP_PLAN_MODE_CONFIGS, DEEP_PLAN_MODES } from '@shared/types';
 import { bridge } from '../api/bridge';
 import { useApp } from '../store/app';
 import { useDeepPlan } from '../store/deepPlan';
@@ -46,6 +48,7 @@ export function DeepPlanMode(): JSX.Element {
   } = useDeepPlan();
 
   const [intentDraft, setIntentDraft] = useState('');
+  const [intentMode, setIntentMode] = useState<DeepPlanMode>('argumentative-essay');
   const [rightTab, setRightTab] = useState<'vision' | 'anchors' | 'graph'>('vision');
 
   const pushResearchEvent = useResearchEvents((s) => s.push);
@@ -79,9 +82,9 @@ export function DeepPlanMode(): JSX.Element {
     async (e: React.FormEvent) => {
       e.preventDefault();
       if (!intentDraft.trim()) return;
-      await start(intentDraft.trim());
+      await start(intentDraft.trim(), intentMode);
     },
-    [intentDraft, start],
+    [intentDraft, intentMode, start],
   );
 
   const session = status?.session ?? null;
@@ -126,6 +129,8 @@ export function DeepPlanMode(): JSX.Element {
               project={project?.name ?? 'this project'}
               draft={intentDraft}
               onDraft={setIntentDraft}
+              mode={intentMode}
+              onMode={setIntentMode}
               onSubmit={handleStart}
               busy={busy}
               disabled={!hasOpenRouterKey}
@@ -187,9 +192,11 @@ export function DeepPlanMode(): JSX.Element {
 }
 
 function IntentForm({
-  project,
+  project: _project,
   draft,
   onDraft,
+  mode,
+  onMode,
   onSubmit,
   busy,
   disabled,
@@ -197,24 +204,45 @@ function IntentForm({
   project: string;
   draft: string;
   onDraft: (s: string) => void;
+  mode: DeepPlanMode;
+  onMode: (m: DeepPlanMode) => void;
   onSubmit: (e: React.FormEvent) => void;
   busy: boolean;
   disabled: boolean;
 }): JSX.Element {
+  const config = DEEP_PLAN_MODE_CONFIGS[mode];
   return (
     <div className="dp-intent">
       <div className="dp-intent-card">
-        <h1>What are we making?</h1>
+        <h1>What kind of work is this?</h1>
         <p className="dp-muted">
-          Describe the piece of writing you want to end up with. A few sentences is plenty —
-          the planner will ask follow-up questions.
+          Pick a deliverable — the panel and drafter shape themselves around your choice. Then describe what you're making.
         </p>
         <form onSubmit={onSubmit}>
+          <div className="dp-mode-grid" role="radiogroup" aria-label="Deliverable mode">
+            {DEEP_PLAN_MODES.map((id) => {
+              const cfg = DEEP_PLAN_MODE_CONFIGS[id];
+              const active = id === mode;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  className={`dp-mode-card${active ? ' is-active' : ''}`}
+                  onClick={() => onMode(id)}
+                  disabled={busy || disabled}
+                >
+                  <span className="dp-mode-card-label">{cfg.label}</span>
+                  <span className="dp-mode-card-blurb">{cfg.blurb}</span>
+                </button>
+              );
+            })}
+          </div>
           <textarea
-            autoFocus
-            rows={6}
+            rows={5}
             className="dp-intent-textarea"
-            placeholder={`e.g. An essay for ${project} exploring the future of open-source model economics…`}
+            placeholder={config.briefPlaceholder}
             value={draft}
             onChange={(e) => onDraft(e.target.value)}
             disabled={busy || disabled}

--- a/src/renderer/src/components/Login.tsx
+++ b/src/renderer/src/components/Login.tsx
@@ -1,17 +1,8 @@
-import { useState } from 'react';
 import logoUrl from '../assets/logo.svg';
 import { useAuth } from '../store/auth';
 
 export function Login(): JSX.Element {
-  const { signIn, pasteToken, loading, error, dismissError } = useAuth();
-  const [showPaste, setShowPaste] = useState(false);
-  const [token, setToken] = useState('');
-
-  const onPaste = async (): Promise<void> => {
-    if (!token.trim()) return;
-    await pasteToken(token.trim());
-    setToken('');
-  };
+  const { signIn, loading, error, dismissError } = useAuth();
 
   return (
     <div className="welcome">
@@ -31,40 +22,7 @@ export function Login(): JSX.Element {
           >
             Sign in with browser
           </button>
-          <button
-            type="button"
-            onClick={() => setShowPaste((v) => !v)}
-            disabled={loading}
-          >
-            {showPaste ? 'Hide' : 'I have a token'}
-          </button>
         </div>
-
-        {showPaste && (
-          <div className="login-paste">
-            <p className="muted">
-              Copy the token from the login page and paste it below. We'll store it
-              securely in your OS keychain.
-            </p>
-            <div className="row">
-              <input
-                type="password"
-                placeholder="omk_live_..."
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                autoFocus
-              />
-              <button
-                type="button"
-                className="primary"
-                onClick={() => void onPaste()}
-                disabled={loading || token.trim().length === 0}
-              >
-                Use token
-              </button>
-            </div>
-          </div>
-        )}
 
         {error && (
           <div className="error" role="alert">
@@ -78,7 +36,7 @@ export function Login(): JSX.Element {
         <div className="welcome-footer">
           <span className="hint">
             After signing in on the web, your browser will hand the session back to
-            this app automatically. If it doesn't, click "I have a token" above.
+            this app automatically.
           </span>
         </div>
       </div>

--- a/src/renderer/src/components/SourcePreview.tsx
+++ b/src/renderer/src/components/SourcePreview.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import type { SourceRole } from '@shared/types';
 import { bridge } from '../api/bridge';
 import { useSourcePreview } from '../store/sourcePreview';
 import { renderMarkdown } from '../utils/markdown';
@@ -34,7 +35,19 @@ export function SourcePreviewPopup(): JSX.Element | null {
     [open],
   );
 
+  const handleSetRole = useCallback(
+    async (role: SourceRole) => {
+      if (!source) return;
+      const updated = await bridge.sources.setRole(source.slug, role);
+      open(updated);
+    },
+    [source, open],
+  );
+
   if (!source) return null;
+
+  const role: SourceRole = source.role ?? 'reference';
+  const isRaw = source.type === 'raw';
 
   return (
     <div className="source-preview-overlay" onClick={close}>
@@ -50,6 +63,32 @@ export function SourcePreviewPopup(): JSX.Element | null {
           onClick={handleBodyClick}
           dangerouslySetInnerHTML={{ __html: html }}
         />
+        {!isRaw && (
+          <div className="source-role-toggle" role="group" aria-label="Source role">
+            <span className="source-role-label">Role</span>
+            <div className="source-role-buttons">
+              <button
+                type="button"
+                className={`source-role-btn${role === 'reference' ? ' is-active' : ''}`}
+                onClick={() => void handleSetRole('reference')}
+              >
+                Reference
+              </button>
+              <button
+                type="button"
+                className={`source-role-btn${role === 'guidance' ? ' is-active' : ''}`}
+                onClick={() => void handleSetRole('guidance')}
+              >
+                Guidance
+              </button>
+            </div>
+            <span className="source-role-hint">
+              {role === 'reference'
+                ? 'Cited inline + listed in references.'
+                : 'Method/framework — informs how the draft is written, never cited.'}
+            </span>
+          </div>
+        )}
         {source.sourcePath && (
           <div className="source-preview-path">{source.sourcePath}</div>
         )}

--- a/src/renderer/src/components/SourcePreview.tsx
+++ b/src/renderer/src/components/SourcePreview.tsx
@@ -82,11 +82,22 @@ export function SourcePreviewPopup(): JSX.Element | null {
                 Guidance
               </button>
             </div>
-            <span className="source-role-hint">
-              {role === 'reference'
-                ? 'Cited inline + listed in references.'
-                : 'Method/framework — informs how the draft is written, never cited.'}
-            </span>
+            <ul className="source-role-effects">
+              <li>
+                <span className="source-role-effect-yes">✓</span> Ideas shape the draft
+              </li>
+              <li>
+                {role === 'reference' ? (
+                  <>
+                    <span className="source-role-effect-yes">✓</span> Cited inline + listed in References
+                  </>
+                ) : (
+                  <>
+                    <span className="source-role-effect-no">✗</span> Never cited — applied as method
+                  </>
+                )}
+              </li>
+            </ul>
           </div>
         )}
         {source.sourcePath && (

--- a/src/renderer/src/components/deepPlan/ConversationColumn.tsx
+++ b/src/renderer/src/components/deepPlan/ConversationColumn.tsx
@@ -142,6 +142,19 @@ export function ConversationColumn({ session }: Props): JSX.Element {
         {!roundRunning && pendingQuestions.length > 0 && (
           <QuestionCard questions={pendingQuestions} />
         )}
+        {/* Bridging indicator: after the user submits answers, there's a
+            window where dispatched searches are running and the next
+            panel round hasn't fired yet. Without this the screen looks
+            inert. Show until either the next round starts (roundRunning)
+            or new pending questions appear. */}
+        {busy && !roundRunning && pendingQuestions.length === 0 && (
+          <div className="dp-following-up">
+            <span className="dp-following-up-spinner" aria-hidden />
+            <span className="dp-following-up-text">
+              Following up on your answers — running any delegated research, then reconvening the panel…
+            </span>
+          </div>
+        )}
         {shouldShowAdvanceCta && (
           <PhaseAdvanceCta
             phase={session.phase}
@@ -303,7 +316,7 @@ function MessageBubble({
  */
 function PanelDiscussion({ outputs }: { outputs: PanelOutput[] }): JSX.Element {
   const contributingRoles = outputs.filter(
-    (p) => p.visionNotes.trim().length > 0 || p.needsResearch.length > 0,
+    (p) => p.visionNotes.trim().length > 0 || p.userPrompts.length > 0,
   );
   return (
     <details className="dp-panel-discussion">
@@ -324,7 +337,7 @@ function PanelDiscussion({ outputs }: { outputs: PanelOutput[] }): JSX.Element {
 
 function PanelDiscussionItem({ output }: { output: PanelOutput }): JSX.Element {
   const silent =
-    !output.visionNotes.trim() && output.needsResearch.length === 0;
+    !output.visionNotes.trim() && output.userPrompts.length === 0;
   return (
     <li className={`dp-panel-discussion-item${silent ? ' dp-panel-discussion-item-silent' : ''}`}>
       <div className="dp-panel-discussion-role">{output.role}</div>
@@ -333,7 +346,7 @@ function PanelDiscussionItem({ output }: { output: PanelOutput }): JSX.Element {
       ) : (
         <PanelThoughtBody
           visionNotes={output.visionNotes.trim()}
-          researchRequests={output.needsResearch}
+          userPrompts={output.userPrompts}
         />
       )}
     </li>
@@ -341,27 +354,30 @@ function PanelDiscussionItem({ output }: { output: PanelOutput }): JSX.Element {
 }
 
 /**
- * Shared render for a panelist's thought: the vision note + any research
- * requests with their rationale. Used both by the live PanelProgressPanel
- * (while the round is running) and the post-round PanelDiscussion
- * accordion (on completed chair-turn messages), so both paths share the
- * same type scale + bullet style.
+ * Shared render for a panelist's thought: the vision note + any prompts
+ * the panelist proposed for the user. Used both by the live
+ * PanelProgressPanel (while the round is running) and the post-round
+ * PanelDiscussion accordion, so both paths share the same type scale +
+ * bullet style.
  */
 function PanelThoughtBody({
   visionNotes,
-  researchRequests,
+  userPrompts,
 }: {
   visionNotes: string;
-  researchRequests: PanelOutput['needsResearch'];
+  userPrompts: PanelOutput['userPrompts'];
 }): JSX.Element {
   return (
     <div className="dp-panel-role-thought">
       {visionNotes && <p className="dp-panel-role-thought-note">{visionNotes}</p>}
-      {researchRequests.map((req, i) => (
+      {userPrompts.map((u, i) => (
         <p key={i} className="dp-panel-role-thought-search-line">
-          <span className="dp-panel-role-thought-search-label">Search:</span>{' '}
-          <span className="dp-panel-role-thought-search-query">{req.query}</span>
-          {req.rationale && <> - {req.rationale}</>}
+          <span className="dp-panel-role-thought-search-label">{u.kind}:</span>{' '}
+          <span className="dp-panel-role-thought-search-query">{u.prompt}</span>
+          {u.rationale && <> — {u.rationale}</>}
+          {u.delegableQuery && (
+            <> · <em>can search "{u.delegableQuery}"</em></>
+          )}
         </p>
       ))}
     </div>
@@ -552,8 +568,8 @@ function PanelProgressPanel({ progress }: PanelProgressPanelProps): JSX.Element 
               : undefined;
           const visionNotes =
             entry?.state === 'done' ? entry.visionNotes.trim() : '';
-          const researchRequests =
-            entry?.state === 'done' ? entry.needsResearch : [];
+          const userPrompts =
+            entry?.state === 'done' ? entry.userPrompts : [];
           const errorMsg = entry?.state === 'failed' ? entry.error : undefined;
 
           return (
@@ -574,14 +590,14 @@ function PanelProgressPanel({ progress }: PanelProgressPanelProps): JSX.Element 
                   />
                 </div>
                 {/* Live panel thought. While running we show the persona's
-                 *  tagline; when the role finishes, its actual vision note
-                 *  + research requests replace the tagline immediately so
-                 *  users read the panel's thinking while the Chair is
+                 *  tagline; when the role finishes, its vision note + any
+                 *  user-prompts it raised replace the tagline immediately
+                 *  so users read the panel's thinking while the Chair is
                  *  still synthesising. */}
-                {state === 'done' && (visionNotes || researchRequests.length > 0) ? (
+                {state === 'done' && (visionNotes || userPrompts.length > 0) ? (
                   <PanelThoughtBody
                     visionNotes={visionNotes}
-                    researchRequests={researchRequests}
+                    userPrompts={userPrompts}
                   />
                 ) : state === 'done' ? (
                   <div className="dp-panel-role-tagline dp-panel-role-silent">No notes.</div>

--- a/src/renderer/src/components/deepPlan/QuestionCard.tsx
+++ b/src/renderer/src/components/deepPlan/QuestionCard.tsx
@@ -1,6 +1,28 @@
 import { useMemo, useState } from 'react';
 import type { ChairAnswer, ChairAnswerMap, ChairQuestion } from '@shared/types';
+import { DELEGATE_TO_RESEARCH } from '@shared/types';
 import { useDeepPlan } from '../../store/deepPlan';
+import { renderMarkdownInline } from '../../utils/markdown';
+
+/**
+ * Pretty role labels for the "X asks:" attribution shown above each
+ * question when the Chair surfaced a panelist-proposed prompt. The Chair
+ * uses Title Case here so the user sees "Skeptic asks…" not "skeptic asks…".
+ */
+const ROLE_LABELS: Record<string, string> = {
+  explorer: 'Explorer',
+  scoper: 'Scoper',
+  stakes: 'Stakes-Raiser',
+  architect: 'Architect',
+  evidence: 'Evidence Scout',
+  steelman: 'Steelman',
+  skeptic: 'Skeptic',
+  adversary: 'Adversary',
+  editor: 'Editor',
+  audience: 'Audience',
+  finaliser: 'Finaliser',
+  chair: 'Chair',
+};
 
 /**
  * Carousel of Chair-authored questions. The user steps through them one
@@ -147,9 +169,21 @@ export function QuestionCard({ questions }: Props): JSX.Element | null {
         <span className="dp-qcard-type">{typeLabel}</span>
       </div>
 
-      <div className="dp-qcard-prompt">{current.prompt}</div>
+      {current.proposedBy && current.proposedBy !== 'chair' && (
+        <div className="dp-qcard-attribution">
+          {ROLE_LABELS[current.proposedBy] ?? current.proposedBy} asks
+        </div>
+      )}
+
+      <div
+        className="dp-qcard-prompt dp-md"
+        dangerouslySetInnerHTML={{ __html: renderMarkdownInline(current.prompt) }}
+      />
       {current.rationale && (
-        <div className="dp-qcard-rationale">{current.rationale}</div>
+        <div
+          className="dp-qcard-rationale dp-md"
+          dangerouslySetInnerHTML={{ __html: renderMarkdownInline(current.rationale) }}
+        />
       )}
 
       <div className="dp-qcard-field">
@@ -171,7 +205,10 @@ export function QuestionCard({ questions }: Props): JSX.Element | null {
                   disabled={busy}
                 >
                   <span className="dp-qcard-choice-mark dp-qcard-choice-mark-radio" aria-hidden />
-                  <span className="dp-qcard-choice-label">{c.label}</span>
+                  <span
+                    className="dp-qcard-choice-label dp-md"
+                    dangerouslySetInnerHTML={{ __html: renderMarkdownInline(c.label) }}
+                  />
                   {c.recommended && (
                     <span className="dp-qcard-choice-ribbon">Panel pick</span>
                   )}
@@ -237,7 +274,10 @@ export function QuestionCard({ questions }: Props): JSX.Element | null {
                   <span className="dp-qcard-choice-mark dp-qcard-choice-mark-check" aria-hidden>
                     {picked && '✓'}
                   </span>
-                  <span className="dp-qcard-choice-label">{c.label}</span>
+                  <span
+                    className="dp-qcard-choice-label dp-md"
+                    dangerouslySetInnerHTML={{ __html: renderMarkdownInline(c.label) }}
+                  />
                 </button>
               );
             })}
@@ -273,6 +313,17 @@ export function QuestionCard({ questions }: Props): JSX.Element | null {
         >
           Let the panel decide
         </button>
+        {current.delegableQuery && (
+          <button
+            type="button"
+            className="dp-qcard-delegate"
+            onClick={() => void handleNext(DELEGATE_TO_RESEARCH)}
+            disabled={busy}
+            title={`Search the web: "${current.delegableQuery}"`}
+          >
+            🔍 Research this
+          </button>
+        )}
         <button
           type="button"
           className="dp-qcard-next"

--- a/src/renderer/src/store/deepPlan.ts
+++ b/src/renderer/src/store/deepPlan.ts
@@ -7,6 +7,7 @@ import type {
   PanelProgressEvent,
   PanelResearchRequest,
   PanelRole,
+  PanelUserPrompt,
 } from '@shared/types';
 import { bridge } from '../api/bridge';
 
@@ -30,6 +31,7 @@ export type PanelRoleStatus =
       /** Streamed through from the main process when the role finishes. */
       visionNotes: string;
       needsResearch: PanelResearchRequest[];
+      userPrompts: PanelUserPrompt[];
     }
   | { state: 'failed'; error: string };
 
@@ -249,6 +251,7 @@ export const useDeepPlan = create<DeepPlanState>((set, get) => ({
             searchQueries: event.searchQueries,
             visionNotes: event.visionNotes,
             needsResearch: event.needsResearch,
+            userPrompts: event.userPrompts,
           };
           return { panelProgress: progress };
         case 'role-failed':

--- a/src/renderer/src/store/deepPlan.ts
+++ b/src/renderer/src/store/deepPlan.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type {
   ChairAnswerMap,
+  DeepPlanMode,
   DeepPlanSession,
   DeepPlanStatus,
   PanelProgressEvent,
@@ -56,7 +57,7 @@ interface DeepPlanState {
   refresh: () => Promise<void>;
   show: () => void;
   hide: () => void;
-  start: (task: string) => Promise<void>;
+  start: (task: string, mode: DeepPlanMode) => Promise<void>;
   sendMessage: (message: string) => Promise<void>;
   chat: (message: string) => Promise<void>;
   runPanel: () => Promise<void>;
@@ -96,10 +97,10 @@ export const useDeepPlan = create<DeepPlanState>((set, get) => ({
   hide: () => set({ visible: false }),
   clearError: () => set({ error: null }),
 
-  start: async (task) => {
+  start: async (task, mode) => {
     set({ busy: true, error: null, panelProgress: emptyPanelProgress() });
     try {
-      const status = await bridge.deepPlan.start(task);
+      const status = await bridge.deepPlan.start(task, mode);
       set({ status, visible: true });
     } catch (err) {
       set({ error: (err as Error).message });

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1230,6 +1230,52 @@ img.login-logo {
   color: var(--fg-muted);
   word-break: break-all;
 }
+.source-role-toggle {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.source-role-label {
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.source-role-buttons {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  align-self: flex-start;
+}
+.source-role-btn {
+  background: var(--bg-alt);
+  color: var(--fg-muted);
+  border: none;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+.source-role-btn + .source-role-btn {
+  border-left: 1px solid var(--border);
+}
+.source-role-btn:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+.source-role-btn.is-active {
+  background: var(--accent);
+  color: var(--bg);
+}
+.source-role-hint {
+  font-size: 11px;
+  color: var(--fg-muted);
+  line-height: 1.45;
+}
 
 /* ---- Document Files ---- */
 .docfiles-panel {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1271,10 +1271,32 @@ img.login-logo {
   background: var(--accent);
   color: var(--bg);
 }
-.source-role-hint {
+.source-role-effects {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
   font-size: 11px;
   color: var(--fg-muted);
   line-height: 1.45;
+}
+.source-role-effects li {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.source-role-effect-yes {
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 12px;
+}
+.source-role-effect-no {
+  color: var(--fg-muted);
+  font-weight: 600;
+  font-size: 12px;
+  opacity: 0.7;
 }
 
 /* ---- Document Files ---- */

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -475,7 +475,7 @@ h3 {
   align-self: center;
   width: 100%;
 }
-.welcome-tagline {
+.welcome-home .welcome-tagline {
   font-size: 17px;
   font-weight: 500;
   color: var(--fg);

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3582,8 +3582,55 @@ img.login-logo {
   padding: 40px;
 }
 .dp-intent-card {
-  max-width: 600px;
+  max-width: 720px;
   width: 100%;
+}
+.dp-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+.dp-mode-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  text-align: left;
+  padding: 12px 14px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--fg);
+  cursor: pointer;
+  transition:
+    border-color var(--dur) var(--ease),
+    background var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease);
+  font-family: var(--font-ui);
+}
+.dp-mode-card:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+.dp-mode-card.is-active {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}
+.dp-mode-card:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.dp-mode-card-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.dp-mode-card-blurb {
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1.45;
 }
 .dp-intent-card h1 {
   margin: 0 0 8px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3173,6 +3173,34 @@ img.login-logo {
   color: var(--muted);
   line-height: 1.5;
 }
+.dp-following-up {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 14px 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-alt);
+  font-size: 13px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+}
+.dp-following-up-spinner {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: dp-following-up-spin 0.9s linear infinite;
+}
+.dp-following-up-text {
+  flex: 1;
+}
+@keyframes dp-following-up-spin {
+  to { transform: rotate(360deg); }
+}
 
 /* Sources column */
 .dp-sources {
@@ -5003,6 +5031,14 @@ img.login-logo {
 .dp-qcard-type {
   color: var(--accent);
 }
+.dp-qcard-attribution {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  margin-bottom: -4px;
+}
 .dp-qcard-prompt {
   font-size: 18px;
   line-height: 1.4;
@@ -5148,6 +5184,28 @@ img.login-logo {
 }
 .dp-qcard-skip:disabled {
   opacity: 0.4;
+  cursor: not-allowed;
+}
+.dp-qcard-delegate {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 9px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-alt);
+  color: var(--fg);
+  cursor: pointer;
+  transition:
+    background var(--dur) var(--ease),
+    border-color var(--dur) var(--ease);
+}
+.dp-qcard-delegate:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+.dp-qcard-delegate:disabled {
+  opacity: 0.45;
   cursor: not-allowed;
 }
 .dp-qcard-next {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -15,6 +15,7 @@ import type {
   AnchorLogEntry,
   SourceAnchor,
   SourceMeta,
+  SourceRole,
   UpdateStatus,
   WikiGraph,
   WorkspaceProject,
@@ -105,6 +106,7 @@ export interface MystApi {
       sourceUrl?: string;
     } | null>;
     delete: (slug: string) => Promise<void>;
+    setRole: (slug: string, role: SourceRole) => Promise<SourceMeta>;
     onChanged: (callback: () => void) => () => void;
   };
   comments: {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -13,6 +13,7 @@ import type {
   ProjectMeta,
   Result,
   AnchorLogEntry,
+  DeepPlanMode,
   SourceAnchor,
   SourceMeta,
   SourceRole,
@@ -145,7 +146,7 @@ export interface MystApi {
   };
   deepPlan: {
     status: () => Promise<DeepPlanStatus>;
-    start: (task: string) => Promise<DeepPlanStatus>;
+    start: (task: string, mode?: DeepPlanMode) => Promise<DeepPlanStatus>;
     sendMessage: (message: string) => Promise<DeepPlanStatus>;
     /** Cheap free-chat with the Chair — single LLM call, no panel, no plan rewrite. */
     chat: (message: string) => Promise<DeepPlanStatus>;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -83,6 +83,7 @@ export const IpcChannels = {
     Read: 'sources:read',
     LookupAnchor: 'sources:lookup-anchor',
     Delete: 'sources:delete',
+    SetRole: 'sources:set-role',
     Changed: 'sources:changed',
   },
   Wiki: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -269,6 +269,96 @@ export interface WikiGraph {
  * same inner loop (panel → research-if-needed → chair → user answers)
  * until the Chair signals `phaseAdvance` or the user forces it.
  */
+/**
+ * The kind of research deliverable the user is making. Picked upfront on
+ * Deep Plan start; drives the Chair's vision template, the drafter's
+ * output structure, and (eventually) the panel's role mix. The point of
+ * an explicit mode is that "I have a half-baked idea" should NOT produce
+ * an essay defending the idea as if established — different deliverables
+ * want different shapes from the panel and the drafter.
+ *
+ * Modes:
+ * - `argumentative-essay` — Defend a thesis with cited evidence. The
+ *   default, the legacy behaviour. Best when the user knows what they
+ *   want to argue and needs help arguing it.
+ * - `idea-exploration` — Pressure-test a half-baked concept. Drafter
+ *   does NOT manufacture a thesis; instead surveys prior art, evaluates
+ *   strengths/weaknesses, and proposes concrete directions. Output reads
+ *   as a conceptual workshop, not an essay.
+ * - `literature-review` — Survey + synthesis across sources. Per-source
+ *   sections (Article 1, Article 2, …) each with intro/summary/analysis,
+ *   followed by a final synthesis comparing them.
+ * - `analytical-report` — User has data/observations + sources, wants a
+ *   structured findings document. Methods → Findings → Discussion.
+ *   Reads raw-source files (CSV/JSON/code) when available.
+ * - `comparative-analysis` — Compare 2+ things across criteria. Drafter
+ *   structures by criterion or by subject.
+ */
+export type DeepPlanMode =
+  | 'argumentative-essay'
+  | 'idea-exploration'
+  | 'literature-review'
+  | 'analytical-report'
+  | 'comparative-analysis';
+
+export const DEEP_PLAN_MODES: DeepPlanMode[] = [
+  'argumentative-essay',
+  'idea-exploration',
+  'literature-review',
+  'analytical-report',
+  'comparative-analysis',
+];
+
+export interface DeepPlanModeConfig {
+  id: DeepPlanMode;
+  /** Short label for the mode picker card. */
+  label: string;
+  /** One-line description shown under the label. */
+  blurb: string;
+  /** Placeholder text for the brief textarea, tailored to the mode. */
+  briefPlaceholder: string;
+}
+
+export const DEEP_PLAN_MODE_CONFIGS: Record<DeepPlanMode, DeepPlanModeConfig> = {
+  'argumentative-essay': {
+    id: 'argumentative-essay',
+    label: 'Argumentative essay',
+    blurb: 'Defend a thesis with cited evidence. The classic essay shape.',
+    briefPlaceholder:
+      'e.g. A 2000-word essay arguing that minimum wages distort labour markets less than common claims suggest, for an econ-curious general audience…',
+  },
+  'idea-exploration': {
+    id: 'idea-exploration',
+    label: 'Idea exploration',
+    blurb:
+      'Pressure-test a half-baked concept. Find prior art, weigh strengths/weaknesses, surface concrete directions.',
+    briefPlaceholder:
+      'e.g. I have a concept I call RLVT — using a judge LLM to audit reasoning chains rather than just score them. Find prior art, stress-test the idea, and tell me where it could go.',
+  },
+  'literature-review': {
+    id: 'literature-review',
+    label: 'Literature review',
+    blurb: 'Survey + synthesise existing work across multiple sources.',
+    briefPlaceholder:
+      'e.g. A 1200-word literature review of fish welfare assessment methods in aquaculture, evaluating two articles for a vet-science assignment…',
+  },
+  'analytical-report': {
+    id: 'analytical-report',
+    label: 'Analytical report',
+    blurb:
+      'Data/observations + sources → structured findings. Methods → Findings → Discussion.',
+    briefPlaceholder:
+      'e.g. An analytical report on the survey data I uploaded, situating the findings in the literature on remote-work productivity…',
+  },
+  'comparative-analysis': {
+    id: 'comparative-analysis',
+    label: 'Comparative analysis',
+    blurb: 'Compare 2+ things across explicit criteria, evidence-grounded.',
+    briefPlaceholder:
+      'e.g. A comparative analysis of three constitutional approaches to free-speech regulation, judged on consistency, scope, and enforcement…',
+  },
+};
+
 export type DeepPlanPhase = 'ideation' | 'planning' | 'reviewing' | 'done';
 
 export const DEEP_PLAN_PHASE_ORDER: DeepPlanPhase[] = [
@@ -524,6 +614,12 @@ export interface DeepPlanSession {
   phase: DeepPlanPhase;
   /** The user's original task string, preserved verbatim. */
   task: string;
+  /**
+   * Deliverable kind, picked upfront. Controls the Chair's vision
+   * template + drafter's output structure. Existing sessions backfill to
+   * `'argumentative-essay'` (the legacy behaviour).
+   */
+  mode: DeepPlanMode;
   /** Hard constraints parsed from `task` on session creation. */
   requirements: PlanRequirements;
   /**
@@ -545,6 +641,14 @@ export interface DeepPlanSession {
    * happens. Keeps the panel's expensive fanout out of casual conversation.
    */
   pendingChatNotes: string[];
+  /**
+   * Anchor ids the Chair has already been shown in prior rounds. Used to
+   * dedupe what we send to the Chair each round — only NEW anchors get
+   * rendered in the prompt. Keeps the Chair's context tight as the wiki
+   * grows AND forces it to ground each vision update in evidence it
+   * hasn't already had a chance to use.
+   */
+  seenAnchorIds: string[];
   /** Running count of panel rounds per phase (convergence heuristic). */
   roundsPerPhase: Record<DeepPlanPhase, number>;
   /** Running total of web-search queries dispatched by the panel. Capped at DEEP_PLAN_MAX_TOTAL_SEARCHES. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -399,16 +399,63 @@ export interface PanelResearchRequest {
 }
 
 /**
- * Panel output in the simplified architecture: the panel is a vision-
- * steering + research-proposing layer, nothing more. Anchor curation is
- * GONE — every anchor extracted during source digest flows directly to
- * the drafter and the Anchors UI tab, deterministically, no middleman.
+ * Categorisation of the things a panelist wants to put in front of the user.
+ * Drives the small UI tag rendered above each prompt so the user sees at a
+ * glance what kind of input is being asked for.
+ */
+export type PanelUserPromptKind = 'concern' | 'question' | 'clarification' | 'idea';
+
+/**
+ * Something the panelist wants the user to weigh in on — concern, question,
+ * clarification, or idea. Replaces the old "panel autonomously fires search"
+ * loop: when a panelist would have searched, it now ASKS first, attaching
+ * the proposed query as a `delegableQuery`. The Chair selects the strongest
+ * prompts to surface, and the user either steers (vision sharpened) or
+ * delegates (search dispatches before next round).
+ */
+export interface PanelUserPrompt {
+  kind: PanelUserPromptKind;
+  /** The prompt as the user will see it — one clear sentence ideally. */
+  prompt: string;
+  /** One-line context — why the panelist is raising this. */
+  rationale: string;
+  /**
+   * Optional research query to fire iff the user delegates. Phrased as a
+   * standalone search query, not a sentence. e.g. "RLVT verifiable reasoning
+   * judge LLM prior art".
+   */
+  delegableQuery?: string;
+}
+
+/**
+ * Panel output. Each panelist contributes three lanes:
+ *
+ * - `visionNotes` — private synthesis input for the Chair.
+ * - `needsResearch[]` — searches the panelist is CONFIDENT need to fire
+ *   regardless of user input (clear wiki coverage gap). Auto-dispatched
+ *   by `runPanelRound` against the session's search budget. Use sparingly
+ *   — every fired search costs latency and pollutes the wiki if the
+ *   results are weak.
+ * - `userPrompts[]` — concerns / questions / clarifications / ideas to
+ *   put in front of the writer. Optionally carry a `delegableQuery`
+ *   that fires ONLY if the user picks "research this". This is the
+ *   probing lane: "have you considered X?", "want me to look this up?".
  */
 export interface PanelOutput {
   role: PanelRole;
   /** Short free-text: what's missing or off about the vision. ≤ 2 sentences. */
   visionNotes: string;
+  /**
+   * Auto-dispatched search queries. Capped per panelist + per round in
+   * the prompt; merged + deduped across panelists at dispatch time.
+   */
   needsResearch: PanelResearchRequest[];
+  /**
+   * Concerns / questions / clarifications / ideas this panelist wants in
+   * front of the user. Capped per panelist in the prompt; Chair selects
+   * the strongest few to surface as ChairQuestions.
+   */
+  userPrompts: PanelUserPrompt[];
 }
 
 export type ChairQuestionType = 'choice' | 'multi' | 'open' | 'confirm';
@@ -438,6 +485,20 @@ export interface ChairQuestion {
    * or type a freeform answer. Defaults off.
    */
   allowCustom?: boolean;
+  /**
+   * Who proposed this question. `'chair'` for Chair-originated questions
+   * (rubric gaps, judgment forks). A `PanelRole` when the Chair surfaced
+   * a panelist's prompt. UI uses this to show "Skeptic asks…" attribution
+   * — concrete provenance instead of a faceless committee.
+   */
+  proposedBy?: PanelRole | 'chair';
+  /**
+   * Optional research query attached to this question. When the user picks
+   * the "research this" option, the orchestrator dispatches the query
+   * before the next panel round. Lets a panelist propose a search without
+   * firing it autonomously — search is always user-blessed.
+   */
+  delegableQuery?: string;
 }
 
 /**
@@ -520,6 +581,8 @@ export type PanelProgressEvent =
       visionNotes: string;
       /** Any research queries the role asked for this round — same order the parser produced. */
       needsResearch: PanelResearchRequest[];
+      /** User-prompts the panelist proposed (concerns/questions/clarifications/ideas). Streamed live so the user sees what was raised before the Chair selects. */
+      userPrompts: PanelUserPrompt[];
     }
   | { kind: 'role-failed'; role: PanelRole; error: string }
   | { kind: 'research-dispatched'; queries: number }
@@ -562,14 +625,37 @@ export interface PlanRequirements {
   deliverableFormat: string | null;
 }
 
+/**
+ * Magic answer value used by `ChairAnswerMap` when the user picks the
+ * "research this" option on a question with a `delegableQuery`. The
+ * orchestrator scans answers for this sentinel after `submitAnswers` and
+ * dispatches the matching queries through the research engine before the
+ * next panel round runs.
+ */
+export const DELEGATE_TO_RESEARCH = '__research__';
+
 /** Session-wide research query budget, across all phases combined. */
 export const DEEP_PLAN_MAX_TOTAL_SEARCHES = 20;
 
-/** Per-round cap on panel-dispatched research queries. */
-export const DEEP_PLAN_MAX_SEARCHES_PER_ROUND = 2;
+/**
+ * Soft target for auto-dispatched panel searches per round. ~1 across
+ * the whole panel on typical depth, scaling up to 2–3 for genuinely
+ * novel / under-grounded topics. Each round should fire SOMETHING when
+ * the topic warrants — see the panelist prompt for the rule against
+ * suppressing later rounds because "the wiki already has sources".
+ * Search is per-claim, not per-session.
+ */
+export const DEEP_PLAN_TARGET_SEARCHES_PER_ROUND = 1;
 
-/** Hard ceiling on Chair questions per round. */
-export const DEEP_PLAN_MAX_QUESTIONS_PER_ROUND = 3;
+/**
+ * Soft target for Chair questions per round. The Chair scales UP when
+ * the topic is ambiguous (multiple interpretations, scope under-defined,
+ * the writer is still discovering what they mean) and DOWN when the
+ * topic is clear and the writer's hand is firm. Used as a target —
+ * not a hard cap. Empty rounds (0 questions) are fine once requirements
+ * are pinned and nothing genuinely forks.
+ */
+export const DEEP_PLAN_TARGET_QUESTIONS_PER_ROUND = 2;
 
 /**
  * Soft round limit per phase — once reached, the Chair is strongly

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -123,6 +123,38 @@ export interface Heading {
  * through the normal pipeline. Behaves identically to `pasted` except the
  * origin is a live URL stored in `sourcePath`.
  */
+/**
+ * How the drafter should treat this source.
+ * - `reference` (default): evidence to cite. Inline anchor citations + entry
+ *   in the References section.
+ * - `guidance`: method/framework/style guide. The drafter INTERNALISES its
+ *   instructions but does NOT cite it inline or list it in References. Used
+ *   for things like "How to write a literature review" or "CRAAP test
+ *   handout" — process material, not content.
+ */
+export type SourceRole = 'reference' | 'guidance';
+
+/**
+ * Best-effort bibliographic metadata extracted at ingest time. Populated by
+ * the digest LLM from the source's title page / header / URL. Drafter uses
+ * `(author, year)` style citations whenever this is populated; falls back
+ * to source name when fields are missing.
+ */
+export interface SourceBibliographic {
+  /** Surname-only or institutional name. e.g. "Sen", "Stanford Encyclopedia of Philosophy". */
+  author?: string;
+  /** 4-digit publication year if recoverable. e.g. 1970. */
+  year?: number;
+  /** Source title in original capitalisation. */
+  title?: string;
+  /** Journal / outlet / publisher. e.g. "Journal of Political Economy". */
+  journal?: string;
+  /** Bare DOI without leading "https://doi.org/". */
+  doi?: string;
+  /** Canonical URL where the source lives, when known. */
+  url?: string;
+}
+
 export interface SourceMeta {
   slug: string;
   name: string;
@@ -137,6 +169,9 @@ export interface SourceMeta {
   rawFile?: string;
   /** Byte size of the underlying file — raw sources only, for UI + caps. */
   sizeBytes?: number;
+  /** Defaults to `'reference'` when omitted (older ingests, raw sources). */
+  role?: SourceRole;
+  bibliographic?: SourceBibliographic;
 }
 
 /**
@@ -371,6 +406,10 @@ export interface AnchorLogEntry {
   /** Verbatim passage from the source. 1–4 sentences. */
   text: string;
   keywords: string[];
+  /** Inherits from the source's role. `'reference'` when omitted. */
+  role?: SourceRole;
+  /** Inherits from the source's bibliographic metadata when populated. */
+  bibliographic?: SourceBibliographic;
 }
 
 /**
@@ -415,6 +454,22 @@ export interface PlanRequirements {
   audience: string | null;
   /** Any other hard constraints the user stated verbatim, for the panel to honour. */
   styleNotes: string | null;
+  /**
+   * Named framework / method / theoretical lens the user explicitly asked for
+   * — "Five Domains", "CRAAP test", "BLUF", "STAR method". When present, the
+   * drafter must APPLY the framework as the analytical lens, not write
+   * about it. Stays null when the task didn't name one.
+   */
+  framework: string | null;
+  /**
+   * Specific deliverable format when the user named one beyond the simple
+   * `form` (essay/report/blog). e.g. "literature review", "lab report",
+   * "policy memo", "case study analysis". Drafter uses this to pick
+   * structural conventions (lit review wants Article 1 / Article 2 sections
+   * with intro/summary/analysis/conclusion; lab report wants method/results
+   * /discussion; etc.). Null when the user only named the basic form.
+   */
+  deliverableFormat: string | null;
 }
 
 /** Session-wide research query budget, across all phases combined. */


### PR DESCRIPTION
Summary
New panel output shape. PanelOutput now carries three lanes:

visionNotes — private synthesis input for the Chair (unchanged).
needsResearch[] — auto-firing literature searches when the wiki has clear coverage gaps.
userPrompts[] — concerns / questions / clarifications / ideas surfaced to the writer, optionally with a delegableQuery for "Research this" UX.
Chair curates panel prompts. ChairQuestion extended with proposedBy (panelist role attribution) and delegableQuery. Chair selects the 2–3 strongest panel prompts each round, rephrases for clarity, surfaces with "Skeptic asks…" attribution. Rubric questions still take first priority.

User-gated research. New "🔍 Research this" button in QuestionCard. Picking it stores the DELEGATE_TO_RESEARCH sentinel; submitAnswers scans for delegations and dispatches the matching searches via the research engine BEFORE the next panel round fires, so the next round sees new sources in context.

Decoupled concerns from searches. Explicit rule: a concern in userPrompts and a search in needsResearch are independent lanes. Panelists fire both when the literature gap exists regardless of writer input. Stops the "1 search asked for · never fires" pattern where panelists bundled everything into delegable.

Source-driven prompts. Panelists prompted to cross-examine existing wiki anchors against the vision ("X says Y in your wiki — does that change your stance?") instead of treating sources as one-way evidence.

Bridging loading indicator. New dp-following-up component fills the gap between answer submit and next panel round so users see "Following up on your answers — running any delegated research…" instead of a black screen.

Soft targets, not hard caps. Replaced DEEP_PLAN_MAX_QUESTIONS/SEARCHES_PER_ROUND with DEEP_PLAN_TARGET_* constants. Parser slices kept as sanity backstops (1 needsResearch per panelist, 3 userPrompts per panelist, 6 questions Chair-side). Calibrated through testing to ~2 questions/round and ~1 search/round, scaling up for ambiguous/novel topics.

Per-round consistency. Explicit "search is per-claim, not per-session" rule prevents later rounds from suppressing auto-search just because the wiki has accumulated sources. Softened the prior-summaries wording so panelists don't read it as "don't propose anything new."

Mode-aware cadence. Probe modes (idea-exploration, argumentative-essay) push panelists to surface user-prompts; quiet modes (literature-review, analytical-report, comparative-analysis) bias toward silence and source-driven work.

LaTeX in questions. QuestionCard prompts, rationales, and choice labels now render through renderMarkdownInline so math notation in panel-generated questions displays correctly.

Files touched
src/shared/types.ts — PanelUserPrompt, PanelOutput.userPrompts/needsResearch, ChairQuestion.proposedBy/delegableQuery, DELEGATE_TO_RESEARCH, target constants.
src/main/features/deepPlan/prompts.ts — full panelist + Chair prompt rewrite, mode verbosity, decoupling rule.
src/main/features/deepPlan/parse.ts — userPrompts[] parser, needsResearch[] re-added, proposedBy + delegableQuery on questions.
src/main/features/deepPlan/panel.ts — emits live userPrompts in progress events; auto-merge + dispatch for needsResearch; exported dispatchDelegatedSearches helper.
src/main/features/deepPlan/index.ts — submitAnswers detects + dispatches delegated searches before the next round.
src/renderer/src/components/deepPlan/QuestionCard.tsx — attribution header, delegate button, LaTeX rendering.
src/renderer/src/components/deepPlan/ConversationColumn.tsx — bridging indicator, userPrompts-aware panel discussion, live thought renderer.
src/renderer/src/store/deepPlan.ts — userPrompts on PanelRoleStatus.
src/renderer/src/styles.css — dp-qcard-attribution, dp-qcard-delegate, dp-following-up styles.